### PR TITLE
include implementation-agnostic specification for Legolas tables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,7 @@ makedocs(modules=[Legolas],
          authors="Beacon Biosignals, Inc.",
          pages=["API Documentation" => "index.md",
                 "Tips For Schema Authors" => "schema.md",
+                "Legolas Table Specification" => "specification.md",
                 "FAQ" => "faq.md"])
 
 deploydocs(repo="github.com/beacon-biosignals/Legolas.jl.git",

--- a/docs/src/specification.md
+++ b/docs/src/specification.md
@@ -1,0 +1,14 @@
+# Legolas Table Specification
+
+Legolas.jl's target (de)serialization format, Arrow, already features wide cross-language adoption, enabling serialized "Legolas tables" to be seamlessly read into many non-Julia environments. This brief specification defines the requirements for any given serialized Arrow table to be considered a "valid Legolas table" agnostic to any particular implementation.
+
+Currently, there is only a single requirement: the presence of a `legolas_schema_qualified` field in the Arrow table's metadata.
+
+The `legolas_schema_qualified` field's value should be either:
+
+1. `name@version` where:
+    - `name` is a lowercase alphanumeric string and may include the special characters `.` and `-`
+    - `version` is a non-negative integer
+2. `x>y` where `x` and `y` are valid `legolas_schema_qualified` strings
+
+This field may be employed by consumers to match deserialized Legolas tables to application-layer schema definitions.

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -35,6 +35,7 @@ not a valid schema name.
 Prefer using this constructor over `Legolas.Schema{Symbol(name),version}()` directly.
 """
 function Schema(name::AbstractString, version::Integer)
+    version >= 0 || throw(ArgumentError("`Legolas.Schema` version must be non-negative, recieved: $version"))
     is_valid_schema_name(name) || throw(ArgumentError("argument is not a valid `Legolas.Schema` name: \"$name\""))
     return Schema{Symbol(name),version}()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,6 +92,7 @@ end
 end
 
 @testset "miscellaneous Legolas.Schema / Legolas.Row tests" begin
+    @test_throws ArgumentError("`Legolas.Schema` version must be non-negative, recieved: -1") Schema("good_name", -1)
     @test_throws ArgumentError("argument is not a valid `Legolas.Schema` name: \"bad_name?\"") Schema("bad_name?", 1)
     @test_throws ArgumentError("argument is not a valid `Legolas.Schema` string: \"bad_name>?@1\"") Schema("bad_name>?@1")
 


### PR DESCRIPTION
This will be relevant to reference in downstream specifications (e.g Onda)