### PR TITLE
improve show method

### DIFF
--- a/src/rows.jl
+++ b/src/rows.jl
@@ -184,6 +184,7 @@ function Base.show(io::IO, row::Row)
     print(io, "Row($(getfield(row, :schema)), ")
     show(io, getfield(row, :fields))
     print(io, ")")
+    return nothing
 end
 
 function _parse_schema_expr(x)

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -180,7 +180,11 @@ Tables.columnnames(row::Row) = Tables.columnnames(getfield(row, :fields))
 Base.:(==)(a::Row, b::Row) = getfield(a, :schema) == getfield(b, :schema) && getfield(a, :fields) == getfield(b, :fields)
 Base.isequal(a::Row, b::Row) = isequal(getfield(a, :schema), getfield(b, :schema)) && isequal(getfield(a, :fields), getfield(b, :fields))
 
-Base.show(io::IO, row::Row) = print(io, "Row($(getfield(row, :schema)), $(getfield(row, :fields)))")
+function Base.show(io::IO, row::Row)
+    print(io, "Row($(getfield(row, :schema)), ")
+    show(io, getfield(row, :fields))
+    print(io, ")")
+end
 
 function _parse_schema_expr(x)
     if x isa Expr && x.head == :call && x.args[1] == :> && length(x.args) == 3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,4 +107,8 @@ end
     @test r === Row(Schema("bar", 1), first(Tables.rows(Arrow.Table(Arrow.tobuffer((x=[1],y=[2],z=[3]))))))
     @test r[1] === 3
     @test string(r) == "Row(Schema(\"bar@1\"), (z = 3, x = 1, y = 2))"
+
+
+    long_row = Row(Schema("bar", 1), (x=1, y=2, z=zeros(100, 100)))
+    @test length(sprint(show, long_row; context = :limit => true)) < 200
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,5 +110,5 @@ end
 
 
     long_row = Row(Schema("bar", 1), (x=1, y=2, z=zeros(100, 100)))
-    @test length(sprint(show, long_row; context = :limit => true)) < 200
+    @test length(sprint(show, long_row; context=(:limit => true))) < 200
 end


### PR DESCRIPTION
With this PR, I get

```julia
julia> long_row
Row(Schema("bar@1"), (z = [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0], x = 1, y = 2))
```
where `long_row` is a row I added to the tests.

Without this tweak to the `show` method, I get:

```julia
julia> @test length(sprint(show, long_row; context = :limit => true)) < 200
Test Failed at REPL[13]:1
  Expression: length(sprint(show, long_row; context = :limit => true)) < 200
   Evaluated: 40142 < 200
ERROR: There was an error during testing
```
since it prints the whole matrix. With even bigger rows, I've had the 'ole ctrl-c -> segfault as it tries to convert the entire row into a string and the print it.