### PR TITLE
Be able to serialize `Legolas.Row`s as elements of table (not just entire rows)

### DIFF
--- a/src/Legolas.jl
+++ b/src/Legolas.jl
@@ -1,6 +1,7 @@
 module Legolas
 
 using Tables, Arrow
+using Arrow.ArrowTypes
 
 """
     lift(f, x)


### PR DESCRIPTION
Consider this an issue rather than a PR, because I don't think the approach here really works. I think it's pretty tricky in general, and maybe generating individual methods in the macro (like @jrevels mentioned) is the way to go rather than trying to treat it in general like I do here.

Here, I just try to serialize a `Row{S}` like a `NamedTuple` implied by the schema (i.e. taking the wide type-annotations literally, i.e. if `a::Any`, then we try to make a named tuple with `a::Any`). The idea was it would be pretty simple and the types you put into the schema are literally specifying the Arrow memory layout, and you couldn't have any extra columns.

Giving up for now since I need to do other stuff, but I figured I'd push what I have since maybe at least the tour example could be re-usable in a better version of this.