### PR TITLE
support Legolas.Row (de)serialization as an Arrow column element

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-Arrow = "1.5"
+Arrow = "1.6.2"
 DataFrames = "1"
 Tables = "1.4"
 julia = "1.3"

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -277,3 +277,12 @@ macro row(schema_expr, fields...)
         Legolas.Row{$schema_type}
     end
 end
+
+# support (de)serialization as an Arrow column value via Arrow.ArrowTypes overloads
+
+const LEGOLAS_ROW_ARROW_NAME = Symbol("JuliaLang.Legolas.Row")
+Arrow.ArrowTypes.arrowname(::Type{<:Legolas.Row}) = LEGOLAS_ROW_ARROW_NAME
+Arrow.ArrowTypes.ArrowType(::Type{Legolas.Row{_,F}}) where {_,F} = Tuple{String,Int,F}
+Arrow.ArrowTypes.toarrow(row::Legolas.Row{S}) where {S} = (String(Legolas.schema_name(S)), Legolas.schema_version(S), getfield(row, :fields))
+Arrow.ArrowTypes.JuliaType(::Val{LEGOLAS_ROW_ARROW_NAME}, ::Any) = Legolas.Row
+Arrow.ArrowTypes.fromarrow(::Type{<:Legolas.Row}, name, version, fields) = Legolas.Row(Legolas.Schema(name, version), fields)

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -278,7 +278,14 @@ macro row(schema_expr, fields...)
     end
 end
 
-# support (de)serialization as an Arrow column value via Arrow.ArrowTypes overloads
+# Support (de)serialization as an Arrow column value via Arrow.ArrowTypes overloads.
+#
+# Note that this only really works in relatively simple cases; rely on this at your own peril.
+# See https://github.com/JuliaData/Arrow.jl/issues/230 for more details.
+# 
+# Note also that the limited support here that DOES work participates in SemVer,
+# e.g. if we break this in future Legolas versions we should treat it as a breaking 
+# change and bump version numbers accordingly. 
 
 const LEGOLAS_ROW_ARROW_NAME = Symbol("JuliaLang.Legolas.Row")
 Arrow.ArrowTypes.arrowname(::Type{<:Legolas.Row}) = LEGOLAS_ROW_ARROW_NAME

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,6 +122,8 @@ end
     @test r[1] === 3
     @test string(r) == "Row(Schema(\"bar@1\"), (z = 3, x = 1, y = 2))"
 
+    tbl = Arrow.Table(Arrow.tobuffer((x=[r],)))
+    @test r === tbl.x[1]
 
     long_row = Row(Schema("bar", 1), (x=1, y=2, z=zeros(100, 100)))
     @test length(sprint(show, long_row; context=(:limit => true))) < 200


### PR DESCRIPTION
alternative to https://github.com/beacon-biosignals/Legolas.jl/pull/13

#13 has admirable goals compared to this naive approach (e.g. parity between schema <-> Arrow layout) but I'd guess that the simplicity of just dumping whatever actual whole `fields` value we're given is probably better aligned with user expectations in practice