### PR TITLE
don't document any assumptions on `Row` field order

### DIFF
--- a/examples/tour.jl
+++ b/examples/tour.jl
@@ -82,8 +82,7 @@ row = MyRow(a=1.5, b="hello", c="goodbye", my_other_field=":)", d=2, e=["anythin
 #     - ...may contain any other fields in addition to the required fields
 # - Outputs of `Legolas.Row` constructors...
 #     - ...will contain all required fields ("missing" fields are explicitly presented with `missing` values)
-#     - ...will order all required fields as specificed by the input `Schema`
-#     - ...will contain all given non-required fields after required fields, in the order provided by the caller
+#     - ...will contain all provided non-required fields
 
 #####
 ##### Extending Existing Rows/Schemas


### PR DESCRIPTION
ref https://github.com/beacon-biosignals/Legolas.jl/issues/12#issuecomment-885982341

`Legolas.Row`s will sort input fields into an implementation-defined order, but compliance for any given schema does not require an order. So while the removed lines here are technically correct, they are kind of misleading