### PR TITLE
Create directories when using `Legolas.write(::PosixPath, ...)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -140,8 +140,7 @@ end
 #
 # TODO: upstream improvements to Arrow.jl to obviate these?
 
-write_full_path(path::AbstractString, bytes) = (mkpath(dirname(path)); Base.write(path, bytes))
-write_full_path(path, bytes) = Base.write(path, bytes)
+write_full_path(path, bytes) = (mkpath(dirname(path)); Base.write(path, bytes))
 
 read_arrow(io_or_path::Union{IO,String,Vector{UInt8}}) = Arrow.Table(io_or_path)
 read_arrow(path) = read_arrow(Base.read(path))


### PR DESCRIPTION
When using a `PosixPath` from FilePathsBase.jl we fail to create the intermediate directories like we do for `String` paths. This should allow us to support both properly.

TODO:
- [x] Validate `S3Path` manually
- [x] Validate against a OndaEDF change I'm working on