### PR TITLE
Support `convert` on `Row`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -171,6 +171,9 @@ Row(schema::Schema, fields) = Row(schema, NamedTuple(Tables.Row(fields)))
 Row(schema::Schema, fields::Row) = Row(schema, getfield(fields, :fields))
 Row(schema::Schema, fields::NamedTuple) = Row(schema; fields...)
 
+Base.convert(::Type{Row{S}}, fields) where {S} = Row(S(), fields)
+Base.convert(::Type{Row{S}}, fields::Row) where {S} = Row(S(), fields)  # Dispatch ambiguity fix
+
 Base.propertynames(row::Row) = propertynames(getfield(row, :fields))
 Base.getproperty(row::Row, name::Symbol) = getproperty(getfield(row, :fields), name)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,6 +133,14 @@ end
 
     long_row = Row(Schema("bar", 1), (x=1, y=2, z=zeros(100, 100)))
     @test length(sprint(show, long_row; context=(:limit => true))) < 200
+
+    @testset "Legolas.Row convert" begin
+        nt = (; x=1, y=2, z=3, custom="foo")
+        v = Row{Schema{:bar, 1}}[]
+        push!(v, nt)
+
+        @test first(v) == Row(Schema("bar", 1), nt)
+    end
 end
 
 @testset "isequal, hash" begin


### PR DESCRIPTION
MWE of the original issue encountered which this PR addresses:
```julia
julia> using UUIDs, TimeSpans, Onda

julia> nt = (; recording=uuid4(), file_path="./file", file_format="lpcm", span=TimeSpan(1, 100), kind="kind", channels=string.('a':'c'), sample_unit="microvolt", sample_resolution_in_unit=1.0, sample_offset_in_unit=0.0, sample_type="uint16", sample_rate=256)
(recording = UUID("a57b8e4b-94a2-43d7-a02a-03c1c7ec5ab8"), file_path = "./file", file_format = "lpcm", span = TimeSpan(00:00:00.000000001, 00:00:00.000000100), kind = "kind", channels = ["a", "b", "c"], sample_unit = "microvolt", sample_resolution_in_unit = 1.0, sample_offset_in_unit = 0.0, sample_type = "uint16", sample_rate = 256)

julia> signals = Onda.Signal[]
Legolas.Row{Legolas.Schema{Symbol("onda.signal"), 1}, F} where F[]

julia> push!(signals, nt)
ERROR: MethodError: Cannot `convert` an object of type
  NamedTuple{(:recording, :file_path, :file_format, :span, :kind, :channels, :sample_unit, :sample_resolution_in_unit, :sample_offset_in_unit, :sample_type, :sample_rate), Tuple{UUID, String, String, TimeSpan, String, Vector{String}, String, Float64, Float64, String, Int64}} to an object of type
  Legolas.Row{Legolas.Schema{Symbol("onda.signal"), 1}, F} where F
Closest candidates are:
  convert(::Type{T}, ::T) where T at essentials.jl:205
  (Legolas.Row{Legolas.Schema{Symbol("onda.signal"), 1}, F} where F)(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any; custom...) at deprecated.jl:70
  (Legolas.Row{S, F} where F)(::Any...; kwargs...) where S at /Users/omus/.julia/dev/Legolas/src/rows.jl:168
Stacktrace:
 [1] push!(a::Vector{Legolas.Row{Legolas.Schema{Symbol("onda.signal"), 1}, F} where F}, item::NamedTuple{(:recording, :file_path, :file_format, :span, :kind, :channels, :sample_unit, :sample_resolution_in_unit, :sample_offset_in_unit, :sample_type, :sample_rate), Tuple{UUID, String, String, TimeSpan, String, Vector{String}, String, Float64, Float64, String, Int64}})
   @ Base ./array.jl:932
 [2] top-level scope
   @ REPL[4]:1
```