### PR TITLE
Add `Schema` methods for `Row`s and make `write` more permissive

### DIFF
--- a/src/rows.jl
+++ b/src/rows.jl
@@ -57,6 +57,9 @@ function Schema(s::AbstractString)
     throw(ArgumentError("argument is not a valid `Legolas.Schema` string: \"$s\""))
 end
 
+Schema(::Type{S}) where {S<:Schema} = S()
+Schema(schema::Schema) = schema
+
 """
     schema_name(::Type{<:Legolas.Schema{name}})
     schema_name(::Legolas.Schema{name})
@@ -198,6 +201,16 @@ Row{S}(args...; kwargs...) where {S} = Row(S(), args...; kwargs...)
 Row(schema::Schema, fields) = Row(schema, NamedTuple(Tables.Row(fields)))
 Row(schema::Schema, fields::Row) = Row(schema, getfield(fields, :fields))
 Row(schema::Schema, fields::NamedTuple) = Row(schema; fields...)
+
+"""
+    Legolas.Schema(row::Row)
+    Legolas.Schema(::Type{<:Row})
+
+Return the schema for the given [`Legolas.Row`](@ref) or row type.
+"""
+Schema(row::Row) = Schema(typeof(row))
+Schema(::Type{Row{S}}) where {S} = S()
+Schema(::Type{Row{S,F}}) where {S,F} = S()
 
 Base.propertynames(row::Row) = propertynames(getfield(row, :fields))
 Base.getproperty(row::Row, name::Symbol) = getproperty(getfield(row, :fields), name)

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -91,10 +91,13 @@ function read(io_or_path; validate::Bool=true)
 end
 
 """
-    Legolas.write(io_or_path, table, schema::Schema; validate::Bool=true, kwargs...)
+    Legolas.write(io_or_path, table, row_or_schema; validate::Bool=true, kwargs...)
 
 Write `table` to `io_or_path`, inserting the appropriate `$LEGOLAS_SCHEMA_QUALIFIED_METADATA_KEY`
 field in the written out Arrow metadata.
+
+`row_or_schema` can be a [`Legolas.Row`](@ref) object or type, or a [`Legolas.Schema`](@ref)
+object or type.
 
 If `validate` is `true`, `Legolas.validate` will be called on the table before it written out.
 
@@ -102,8 +105,9 @@ Any other provided `kwargs` are forwarded to an internal invocation of `Arrow.wr
 
 Note that `io_or_path` may be any type that supports `Base.write(io_or_path, bytes::Vector{UInt8})`.
 """
-function write(io_or_path, table, schema::Schema; validate::Bool=true,
+function write(io_or_path, table, row_or_schema; validate::Bool=true,
                metadata=Arrow.getmetadata(table), kwargs...)
+    schema = Schema(row_or_schema)
     validate && Legolas.validate(table, schema)
     schema_metadata = LEGOLAS_SCHEMA_QUALIFIED_METADATA_KEY => schema_qualified_string(schema)
     if isnothing(metadata)


### PR DESCRIPTION
If you need to `Legolas.write` and all you have is the row type definition you get from `@row`, you need to extract the schema in order to pass it to `Legolas.write`. However, there's no particularly convenient or obvious way to do this. To make this and other such situations easier, I've made the following changes:

- `Schema` constructor methods for `Row`, `Type{<:Row}`, `Schema`, and `Type{<:Schema}`. This allows you to call `Schema` on something which has or is itself a schema and get back said schema.
- Remove the type restriction for the schema argument of `Legolas.write`, thereby permitting passing a row, row type, schema, or schema type (or anything else for which a `Schema` method exists).