### PR TITLE
Updates `tour.jl` link be branch agnostic in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@
 
 Legolas.jl is a Julia package that provides [Tables.jl](https://github.com/JuliaData/Tables.jl)-friendly mechanisms for constructing, reading, writing, and validating [Arrow](https://arrow.apache.org/) tables against extensible, versioned, user-specified schemas.
 
-Want to know more? [Take the tour!](https://github.com/beacon-biosignals/Legolas.jl/tree/master/examples/tour.jl)
+Want to know more? [Take the tour!](examples/tour.jl)


### PR DESCRIPTION
Updates README.md link to `tour.jl` to be branch agnostic. Currently the link is hard-coded to the `master` branch (which does not exist)