### PR TITLE
tweak UnknownSchemaError language

### DIFF
--- a/src/rows.jl
+++ b/src/rows.jl
@@ -119,7 +119,7 @@ function Base.showerror(io::IO, e::UnknownSchemaError)
               your environment is as expected).
 
               Note that if you're in this particular situation, you can still load
-              the raw Arrow table as-is via `Arrow.Table`.
+              the raw table as-is. For example, to load an Arrow table, call `Arrow.Table(path)`.
               """)
     return nothing
 end

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -119,7 +119,7 @@ function Base.showerror(io::IO, e::UnknownSchemaError)
               your environment is as expected).
 
               Note that if you're in this particular situation, you can still load
-              the raw table as-is. For example, to load an Arrow table, call `Arrow.Table(path)`.
+              the raw table as-is without Legolas; e.g., to load an Arrow table, call `Arrow.Table(path)`.
               """)
     return nothing
 end


### PR DESCRIPTION
In some Beacon-internal code, I'm using TOML as a serialization format for small tables. You can get UnknownSchemaErrors, which are then confusing if they tell you to `Arrow.Table` it.

Maybe this is one tiny step towards #34 