### PR TITLE
potentially breaking change introduced

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.3.4"
+version = "0.4.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"


### PR DESCRIPTION
#40 introduces a change that is potentially breaking to existing code:  if MyPkg defines a schema extension like `"foo@1" > "bar@1"` and `bar@1` is defined in OtherPkg, but MyPkg does not ever do `using OtherPkg`, the `@row` macro is never run that defines the necessary `schema_qualified_string(::Schema{:bar,1})` method that's recursively called by `schema_qualified_string(::Schema{:foo,1})`.

This is, admittedly, a pretty weird state for a package to be in, but it has occurred "in the wild".  Because #40 introduces a `::Val{...}` that calls `schema_qualified_string`, that gets run at compile time and packages that would previously precompile without error now throw an error.  The error is informative (it says that teh schema defining code was probably not run, which is the case!) but it seems like bad form to introduce a change that could cause previously working code to error at precompile.

I think the solution is to 
- tag a breaking release with the #40 
- add a 0.3.4 release (_without #40) that contains a nice deprecation warning that checks to see if the parent schema is defined, and if it isn't, prints the "maybe you didn't run `@row`" message but does not error

I think this is necessary because it's not really possible to cleanly work around this without making some kind of backward-incompatible or otherwise not-good state.  The best alterantive in my mind is
- Make the arrow name derive from the un-qualified schema string
- Make a later release (after a depcrecation cycle as described above) that uses teh qualified string, but also includes a method for `JuliaType(::Val{$schema_unqualified_string})` in addition to the qualified one, in order to maintain backwards compatibility with tables written before the change

The risk here is that you might get colisions from teh un-qualified strings, but at least you'd see a warning then about the method being replaced.