### PR TITLE
Add `construct` function

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,6 +32,7 @@ Legolas.read
 
 ```@docs
 Legolas.lift
+Legolas.lift_type
 Legolas.assign_to_table_metadata!
 Legolas.gather
 Legolas.locations

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,7 +32,7 @@ Legolas.read
 
 ```@docs
 Legolas.lift
-Legolas.lift_type
+Legolas.construct
 Legolas.assign_to_table_metadata!
 Legolas.gather
 Legolas.locations

--- a/src/Legolas.jl
+++ b/src/Legolas.jl
@@ -13,6 +13,7 @@ originally constructed.
 """
 lift(::Any, ::Union{Nothing,Missing}) = missing
 lift(f, x) = f(x)
+lift(::Type{T}, x::T) where T = x
 
 """
     lift(f)

--- a/src/Legolas.jl
+++ b/src/Legolas.jl
@@ -10,10 +10,11 @@ Return `f(x)` unless `x isa Union{Nothing,Missing}`, in which case return `missi
 This is particularly useful when handling values from `Arrow.Table`, whose null values
 may present as either `missing` or `nothing` depending on how the table itself was
 originally constructed.
+
+See also: [`lift_type`](@ref)
 """
 lift(::Any, ::Union{Nothing,Missing}) = missing
 lift(f, x) = f(x)
-lift(::Type{T}, x::T) where T = x
 
 """
     lift(f)
@@ -21,6 +22,25 @@ lift(::Type{T}, x::T) where T = x
 Returns a curried function, `x -> lift(f,x)`
 """
 lift(f) = Base.Fix1(lift, f)
+
+
+"""
+    lift_type(T::Type, x)
+
+Construct `T(x)` unless `x` is of type `T` or `Missing` then `x` itself will be returned.
+If `x` is of type `Nothing` then the value `missing` will be returned instead.
+
+This is particularly useful when handling values from `Arrow.Table`, whose null values
+may present as either `missing` or `nothing` depending on how the table itself was
+originally constructed.
+
+See also: [`lift`](@ref)
+"""
+lift_type(T::Type, x) = T(x)
+lift_type(::Type{T}, x::T) where T = x
+lift_type(::Type, ::Union{Nothing,Missing}) = missing
+
+lift_type(T::Type) = Base.Fix1(lift_type, T)
 
 const LEGOLAS_SCHEMA_QUALIFIED_METADATA_KEY = "legolas_schema_qualified"
 

--- a/src/Legolas.jl
+++ b/src/Legolas.jl
@@ -2,48 +2,11 @@ module Legolas
 
 using Tables, Arrow
 
-"""
-    lift(f, x)
 
-Return `f(x)` unless `x isa Union{Nothing,Missing}`, in which case return `missing`.
-
-This is particularly useful when handling values from `Arrow.Table`, whose null values
-may present as either `missing` or `nothing` depending on how the table itself was
-originally constructed.
-
-See also: [`lift_type`](@ref)
-"""
-lift(::Any, ::Union{Nothing,Missing}) = missing
-lift(f, x) = f(x)
-
-"""
-    lift(f)
-
-Returns a curried function, `x -> lift(f,x)`
-"""
-lift(f) = Base.Fix1(lift, f)
-
-
-"""
-    lift_type(T::Type, x)
-
-Construct `T(x)` unless `x` is of type `T` or `Missing` then `x` itself will be returned.
-If `x` is of type `Nothing` then the value `missing` will be returned instead.
-
-This is particularly useful when handling values from `Arrow.Table`, whose null values
-may present as either `missing` or `nothing` depending on how the table itself was
-originally constructed.
-
-See also: [`lift`](@ref)
-"""
-lift_type(T::Type, x) = T(x)
-lift_type(::Type{T}, x::T) where T = x
-lift_type(::Type, ::Union{Nothing,Missing}) = missing
-
-lift_type(T::Type) = Base.Fix1(lift_type, T)
 
 const LEGOLAS_SCHEMA_QUALIFIED_METADATA_KEY = "legolas_schema_qualified"
 
+include("lift.jl")
 include("rows.jl")
 include("tables.jl")
 

--- a/src/lift.jl
+++ b/src/lift.jl
@@ -21,19 +21,23 @@ lift(f) = Base.Fix1(lift, f)
 
 
 """
-    lift_type(T::Type, x)
+    construct(T::Type, x)
 
-Construct `T(x)` unless `x` is of type `T` or `Missing` then `x` itself will be returned.
-If `x` is of type `Nothing` then the value `missing` will be returned instead.
+Construct `T(x)` unless `x` is of type `T`, in which case return `x` itself. Useful in
+conjunction with the [`lift`](@ref) function for types which don't have a constructor which
+accepts instances of itself (e.g. `T(::T)`).
 
-This is particularly useful when handling values from `Arrow.Table`, whose null values
-may present as either `missing` or `nothing` depending on how the table itself was
-originally constructed.
+## Examples
+```jldoctest
+julia> using Legolas: lift, construct
 
-See also: [`lift`](@ref)
+julia> lift(Some, Some(1))
+Some(Some(1))
+
+julia> lift(construct(Some), Some(1))
+Some(1)
+```
 """
-lift_type(T::Type, x) = T(x)
-lift_type(::Type{T}, x::T) where T = x
-lift_type(::Type, ::Union{Nothing,Missing}) = missing
-
-lift_type(T::Type) = Base.Fix1(lift_type, T)
+construct(T::Type, x) = T(x)
+construct(::Type{T}, x::T) where T = x
+construct(T::Type) = Base.Fix1(construct, T)

--- a/src/lift.jl
+++ b/src/lift.jl
@@ -55,5 +55,5 @@ Some(1)
 ```
 """
 construct(T::Type, x) = T(x)
-construct(::Type{T}, x::T) where T = x
+construct(::Type{T}, x::T) where {T} = x
 construct(T::Type) = Base.Fix1(construct, T)

--- a/src/lift.jl
+++ b/src/lift.jl
@@ -9,8 +9,8 @@ originally constructed.
 
 See also: [`lift_type`](@ref)
 """
-lift(::Any, ::Union{Nothing,Missing}) = missing
 lift(f, x) = f(x)
+lift(::Any, ::Union{Nothing,Missing}) = missing
 
 """
     lift(f)

--- a/src/lift.jl
+++ b/src/lift.jl
@@ -7,7 +7,7 @@ This is particularly useful when handling values from `Arrow.Table`, whose null 
 may present as either `missing` or `nothing` depending on how the table itself was
 originally constructed.
 
-See also: [`lift_type`](@ref)
+See also: [`construct`](@ref)
 """
 lift(f, x) = f(x)
 lift(::Any, ::Union{Nothing,Missing}) = missing

--- a/src/lift.jl
+++ b/src/lift.jl
@@ -1,0 +1,39 @@
+"""
+    lift(f, x)
+
+Return `f(x)` unless `x isa Union{Nothing,Missing}`, in which case return `missing`.
+
+This is particularly useful when handling values from `Arrow.Table`, whose null values
+may present as either `missing` or `nothing` depending on how the table itself was
+originally constructed.
+
+See also: [`lift_type`](@ref)
+"""
+lift(::Any, ::Union{Nothing,Missing}) = missing
+lift(f, x) = f(x)
+
+"""
+    lift(f)
+
+Returns a curried function, `x -> lift(f,x)`
+"""
+lift(f) = Base.Fix1(lift, f)
+
+
+"""
+    lift_type(T::Type, x)
+
+Construct `T(x)` unless `x` is of type `T` or `Missing` then `x` itself will be returned.
+If `x` is of type `Nothing` then the value `missing` will be returned instead.
+
+This is particularly useful when handling values from `Arrow.Table`, whose null values
+may present as either `missing` or `nothing` depending on how the table itself was
+originally constructed.
+
+See also: [`lift`](@ref)
+"""
+lift_type(T::Type, x) = T(x)
+lift_type(::Type{T}, x::T) where T = x
+lift_type(::Type, ::Union{Nothing,Missing}) = missing
+
+lift_type(T::Type) = Base.Fix1(lift_type, T)

--- a/src/lift.jl
+++ b/src/lift.jl
@@ -28,6 +28,22 @@ conjunction with the [`lift`](@ref) function for types which don't have a constr
 accepts instances of itself (e.g. `T(::T)`).
 
 ## Examples
+
+```jldoctest
+julia> using Legolas: construct
+
+julia> construct(Float64, 1)
+1.0
+
+julia> Some(Some(1))
+Some(Some(1))
+
+julia> construct(Some, Some(1))
+Some(1)
+```
+
+Use the curried form when using `lift`:
+
 ```jldoctest
 julia> using Legolas: lift, construct
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,11 +8,32 @@ include(joinpath(dirname(@__DIR__), "examples", "tour.jl"))
     @test ismissing(Legolas.lift(sin, nothing))
     @test ismissing(Legolas.lift(sin, missing))
     @test Legolas.lift(sin, 1.0) == sin(1.0)
+    @test Legolas.lift(Some, Some(1)) == Some(Some(1))
+
     @test ismissing(Legolas.lift(sin)(nothing))
     @test ismissing(Legolas.lift(sin)(missing))
     @test Legolas.lift(sin)(1.0) == sin(1.0)
+    @test Legolas.lift(Some)(Some(1)) == Some(Some(1))
+end
 
-    @testset "missing identity constructor" begin
+@testset "Legolas.lift_type" begin
+    @test Legolas.lift_type(Int, 0x00) === 0
+    @test Legolas.lift_type(Int, missing) === missing
+    @test Legolas.lift_type(Int, nothing) === missing
+    @test Legolas.lift_type(Some, Some(1)) === Some(1)
+
+    @test Legolas.lift_type(Int)(0x00) === 0
+    @test Legolas.lift_type(Int)(missing) === missing
+    @test Legolas.lift_type(Int)(nothing) === missing
+    @test Legolas.lift_type(Some)(Some(1)) === Some(1)
+
+    # Possible ambigious method call
+    @test Legolas.lift_type(Nothing, nothing) === missing
+
+    # Restrict `lift_type` to types only
+    @test_throws MethodError Legolas.lift_type(sin, missing)
+
+    @testset "undefined identity constructor" begin
         mutable struct PR45
             x::Int
         end
@@ -21,7 +42,7 @@ include(joinpath(dirname(@__DIR__), "examples", "tour.jl"))
         x = Foo(1)
         @test x !== Foo(1)
         @test_throws MethodError Foo(x)  # Type does not define an identity constructor
-        @test Legolas.lift(Foo, x) === x
+        @test Legolas.lift_type(Foo, x) === x
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,18 @@ include(joinpath(dirname(@__DIR__), "examples", "tour.jl"))
     @test ismissing(Legolas.lift(sin)(nothing))
     @test ismissing(Legolas.lift(sin)(missing))
     @test Legolas.lift(sin)(1.0) == sin(1.0)
+
+    @testset "missing identity constructor" begin
+        mutable struct PR45
+            x::Int
+        end
+        Foo = PR45  # Alias to unique struct name
+
+        x = Foo(1)
+        @test x !== Foo(1)
+        @test_throws MethodError Foo(x)  # Type does not define an identity constructor
+        @test Legolas.lift(Foo, x) === x
+    end
 end
 
 @testset "Legolas.location" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ end
 
     # Restrict `lift_type` to types only
     @test_throws MethodError Legolas.lift_type(sin, missing)
+    @test_throws MethodError Legolas.lift_type(sin)
 
     @testset "undefined identity constructor" begin
         mutable struct PR45

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,23 +16,16 @@ include(joinpath(dirname(@__DIR__), "examples", "tour.jl"))
     @test Legolas.lift(Some)(Some(1)) == Some(Some(1))
 end
 
-@testset "Legolas.lift_type" begin
-    @test Legolas.lift_type(Int, 0x00) === 0
-    @test Legolas.lift_type(Int, missing) === missing
-    @test Legolas.lift_type(Int, nothing) === missing
-    @test Legolas.lift_type(Some, Some(1)) === Some(1)
+@testset "Legolas.construct" begin
+    @test Legolas.construct(Int, 0x00) === 0
+    @test Legolas.construct(Some, Some(1)) === Some(1)
 
-    @test Legolas.lift_type(Int)(0x00) === 0
-    @test Legolas.lift_type(Int)(missing) === missing
-    @test Legolas.lift_type(Int)(nothing) === missing
-    @test Legolas.lift_type(Some)(Some(1)) === Some(1)
+    @test Legolas.construct(Int)(0x00) === 0
+    @test Legolas.construct(Some)(Some(1)) === Some(1)
 
-    # Possible ambigious method call
-    @test Legolas.lift_type(Nothing, nothing) === missing
-
-    # Restrict `lift_type` to types only
-    @test_throws MethodError Legolas.lift_type(sin, missing)
-    @test_throws MethodError Legolas.lift_type(sin)
+    # Restrict `construct` to types only
+    @test_throws MethodError Legolas.construct(sin, 1.0)
+    @test_throws MethodError Legolas.construct(sin)
 
     @testset "undefined identity constructor" begin
         mutable struct PR45
@@ -43,7 +36,7 @@ end
         x = Foo(1)
         @test x !== Foo(1)
         @test_throws MethodError Foo(x)  # Type does not define an identity constructor
-        @test Legolas.lift_type(Foo, x) === x
+        @test Legolas.construct(Foo, x) === x
     end
 end
 


### PR DESCRIPTION
Method ensure compatibility with types which do not define constructing instances of themselves. For example with `Time`:

```julia
julia> Time(Time(0))
ERROR: MethodError: no method matching Int64(::Time)
```

We can work around this with `Legolas.lift(x -> x isa Time ? x : Time(x), y)` but with this PR we can simply do `Legolas.lift_type(Time, y)`.