### PR TITLE
Add column name/utility accessors for `Legolas.Schema`

### DIFF
--- a/src/rows.jl
+++ b/src/rows.jl
@@ -105,25 +105,22 @@ struct UnknownSchemaError <: Exception
 end
 
 function Base.showerror(io::IO, e::UnknownSchemaError)
-    print(
-        io,
-        """
-        encountered unknown `Legolas.Schema` type: $(e.schema)
+    print(io, """
+              encountered unknown `Legolas.Schema` type: $(e.schema)
 
-        This generally indicates that this schema has not been defined (i.e.
-        the schema's corresponding `@row` statement has not been executed) in
-        the current Julia session.
+              This generally indicates that this schema has not been defined (i.e.
+              the schema's corresponding `@row` statement has not been executed) in
+              the current Julia session.
 
-        In practice, this can arise if you try to read a Legolas table with a
-        prescribed schema, but haven't actually loaded the schema definition
-        (or commonly, haven't loaded the dependency that contains the schema
-        definition - check the versions of loaded packages/modules to confirm
-        your environment is as expected).
+              In practice, this can arise if you try to read a Legolas table with a
+              prescribed schema, but haven't actually loaded the schema definition
+              (or commonly, haven't loaded the dependency that contains the schema
+              definition - check the versions of loaded packages/modules to confirm
+              your environment is as expected).
 
-        Note that if you're in this particular situation, you can still load
-        the raw table as-is without Legolas; e.g., to load an Arrow table, call `Arrow.Table(path)`.
-        """
-    )
+              Note that if you're in this particular situation, you can still load
+              the raw table as-is without Legolas; e.g., to load an Arrow table, call `Arrow.Table(path)`.
+              """)
     return nothing
 end
 

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -239,6 +239,7 @@ have been inherited from this `Legolas.Schema`'s parent schema.
 schema_field_names(::Type{S}) where {S<:Legolas.Schema} = throw(UnknownSchemaError(S()))
 schema_field_names(s::Legolas.Schema) = schema_field_names(typeof(s))
 schema_field_names(::Legolas.Row{S}) where {S} = schema_field_names(S)
+schema_field_names(::Type{<:Legolas.Row{S}}) where {S} = schema_field_names(S)
 
 """
     schema_field_types(::Legolas.Schema{name,version})
@@ -249,6 +250,7 @@ have been inherited from this `Legolas.Schema`'s parent schema.
 schema_field_types(::Type{S}) where {S<:Legolas.Schema} = throw(UnknownSchemaError(S()))
 schema_field_types(s::Legolas.Schema) = schema_field_types(typeof(s))
 schema_field_types(::Legolas.Row{S}) where {S} = schema_field_types(S)
+schema_field_types(::Type{<:Legolas.Row{S}}) where {S} = schema_field_types(S)
 
 function _parse_schema_expr(x)
     if x isa Expr && x.head == :call && x.args[1] == :> && length(x.args) == 3

--- a/src/rows.jl
+++ b/src/rows.jl
@@ -233,7 +233,6 @@ end
 Get a tuple with the names of the fields of this `Legolas.Schema`, including names that
 have been inherited from this `Legolas.Schema`'s parent schema.
 """
-schema_field_names(::Type{S}) where {S<:Legolas.Schema} = throw(UnknownSchemaError(S()))
 schema_field_names(s::Legolas.Schema) = schema_field_names(typeof(s))
 schema_field_names(::Legolas.Row{S}) where {S} = schema_field_names(S)
 schema_field_names(::Type{<:Legolas.Row{S}}) where {S} = schema_field_names(S)
@@ -244,7 +243,6 @@ schema_field_names(::Type{<:Legolas.Row{S}}) where {S} = schema_field_names(S)
 Get a tuple with the types of the fields of this `Legolas.Schema`, including types of fields that
 have been inherited from this `Legolas.Schema`'s parent schema.
 """
-schema_field_types(::Type{S}) where {S<:Legolas.Schema} = throw(UnknownSchemaError(S()))
 schema_field_types(s::Legolas.Schema) = schema_field_types(typeof(s))
 schema_field_types(::Legolas.Row{S}) where {S} = schema_field_types(S)
 schema_field_types(::Type{<:Legolas.Row{S}}) where {S} = schema_field_types(S)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,10 +187,12 @@ end
     @test Legolas.schema_field_names(Schema{:parent,1}) == parent_fields
     @test Legolas.schema_field_names(Schema("parent@1")) == parent_fields
     @test Legolas.schema_field_names(Parent()) == parent_fields
+    @test Legolas.schema_field_names(Parent) == parent_fields
 
     @test Legolas.schema_field_types(Schema{:parent,1}) == parent_field_types
     @test Legolas.schema_field_types(Schema("parent@1")) == parent_field_types
     @test Legolas.schema_field_types(Parent()) == parent_field_types
+    @test Legolas.schema_field_types(Parent) == parent_field_types
 
     Child = @row("child@1" > "parent@1",
                   first_child_field::Symbol=:first,
@@ -202,10 +204,12 @@ end
     @test Legolas.schema_field_names(Schema{:child,1}) == child_fields
     @test Legolas.schema_field_names(Schema("child@1")) == child_fields
     @test Legolas.schema_field_names(Child()) == child_fields
+    @test Legolas.schema_field_names(Child) == child_fields
 
     @test Legolas.schema_field_types(Schema{:child,1}) == child_field_types
     @test Legolas.schema_field_types(Schema("child@1")) == child_field_types
     @test Legolas.schema_field_types(Child()) == child_field_types
+    @test Legolas.schema_field_types(Child) == child_field_types
 
     @test_throws Legolas.UnknownSchemaError Legolas.schema_field_names(Legolas.Schema("imadethisup@3"))
     @test_throws Legolas.UnknownSchemaError Legolas.schema_field_types(Legolas.Schema("imadethisup@3"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -231,7 +231,7 @@ end
 const MyInnerRow = @row("my-inner-schema@1", b::Int=1)
 const MyOuterRow = @row("my-outer-schema@1",
                         a::String,
-                        x::MyInnerRow = MyInnerRow(x))
+                        x::MyInnerRow=MyInnerRow(x))
 
 @testset "Nested arrow serialization" begin
     table = [MyOuterRow(; a="outer_a", x=MyInnerRow())]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,8 +211,8 @@ end
     @test Legolas.schema_field_types(Child()) == child_field_types
     @test Legolas.schema_field_types(Child) == child_field_types
 
-    @test_throws Legolas.UnknownSchemaError Legolas.schema_field_names(Legolas.Schema("imadethisup@3"))
-    @test_throws Legolas.UnknownSchemaError Legolas.schema_field_types(Legolas.Schema("imadethisup@3"))
+    @test_throws MethodError Legolas.schema_field_names(Legolas.Schema("imadethisup@3"))
+    @test_throws MethodError Legolas.schema_field_types(Legolas.Schema("imadethisup@3"))
 end
 
 @testset "isequal, hash" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,64 +42,64 @@ end
 
 @testset "Legolas.location" begin
     collections = (['a', 'b', 'c', 'f', 'b'],
-                   ['d', 'c', 'e', 'b'],
-                   ['f', 'a', 'f'])
+        ['d', 'c', 'e', 'b'],
+        ['f', 'a', 'f'])
     expected = Dict('f' => ([4], [], [1, 3]),
-                    'a' => ([1], [], [2]),
-                    'c' => ([3], [2], []),
-                    'd' => ([], [1], []),
-                    'e' => ([], [3], []),
-                    'b' => ([2, 5], [4], []))
+        'a' => ([1], [], [2]),
+        'c' => ([3], [2], []),
+        'd' => ([], [1], []),
+        'e' => ([], [3], []),
+        'b' => ([2, 5], [4], []))
     @test Legolas.locations(collections) == expected
 end
 
 @testset "Legolas.gather" begin
     a = [(x=1, y="a", z="k"),
-         (x=2, y="b", z="j"),
-         (x=4, y="c", z="i"),
-         (x=4, y="d", z="h"),
-         (x=2, y="e", z="g"),
-         (x=5, y="f", z="f"),
-         (x=4, y="g", z="e"),
-         (x=3, y="h", z="d"),
-         (x=1, y="i", z="c"),
-         (x=5, y="j", z="b"),
-         (x=4, y="k", z="a")]
+        (x=2, y="b", z="j"),
+        (x=4, y="c", z="i"),
+        (x=4, y="d", z="h"),
+        (x=2, y="e", z="g"),
+        (x=5, y="f", z="f"),
+        (x=4, y="g", z="e"),
+        (x=3, y="h", z="d"),
+        (x=1, y="i", z="c"),
+        (x=5, y="j", z="b"),
+        (x=4, y="k", z="a")]
     b = [(x=1, m=1),
-         (x=2, m=2),
-         (x=2, m=5),
-         (x=5, m=4),
-         (x=4, m=6)]
+        (x=2, m=2),
+        (x=2, m=5),
+        (x=5, m=4),
+        (x=4, m=6)]
     c = [(test="a", x=1, z=1.0),
-         (test="b", x=2, z=1.0),
-         (test="d", x=4, z=1.0),
-         (test="e", x="gotcha", z=1.0),
-         (test="f", x=5, z=1.0),
-         (test="h", x=3, z=1.0),
-         (test="i", x=1, z=1.0),
-         (test="j", x=5, z=1.0),
-         (test="k", x=4, z=1.0)]
+        (test="b", x=2, z=1.0),
+        (test="d", x=4, z=1.0),
+        (test="e", x="gotcha", z=1.0),
+        (test="f", x=5, z=1.0),
+        (test="h", x=3, z=1.0),
+        (test="i", x=1, z=1.0),
+        (test="j", x=5, z=1.0),
+        (test="k", x=4, z=1.0)]
     dfa, dfb, dfc = DataFrame(a), DataFrame(b), DataFrame(c)
     g = Legolas.gather(:x, a, b, c; extract=(t, i) -> t[i])
     dfg = Legolas.gather(:x, dfa, dfb, dfc)
     expected = Dict(1 => ([(x=1, y="a", z="k"), (x=1, y="i", z="c")],
-                          [(x=1, m=1)],
-                          [(test="a", x=1, z=1.0), (test="i", x=1, z=1.0)]),
-                    2 => ([(x=2, y="b", z="j"), (x=2, y="e", z="g")],
-                          [(x=2, m=2), (x=2, m=5)],
-                          [(test="b", x=2, z=1.0)]),
-                    3 => ([(x=3, y="h", z="d")],
-                          NamedTuple{(:x, :m),Tuple{Int64,Int64}}[],
-                          [(test="h", x=3, z=1.0)]),
-                    4 => ([(x=4, y="c", z="i"), (x=4, y="d", z="h"), (x=4, y="g", z="e"), (x=4, y="k", z="a")],
-                          [(x=4, m=6)],
-                          [(test="d", x=4, z=1.0), (test="k", x=4, z=1.0)]),
-                    5 => ([(x=5, y="f", z="f"), (x=5, y="j", z="b")],
-                          [(x=5, m=4)],
-                          [(test="f", x=5, z=1.0), (test="j", x=5, z=1.0)]),
-                    "gotcha" => (NamedTuple{(:x, :y, :z),NTuple{3,Any}}[],
-                                 NamedTuple{(:x, :m),NTuple{2,Any}}[],
-                                 [(test="e", x="gotcha", z=1.0)]))
+            [(x=1, m=1)],
+            [(test="a", x=1, z=1.0), (test="i", x=1, z=1.0)]),
+        2 => ([(x=2, y="b", z="j"), (x=2, y="e", z="g")],
+            [(x=2, m=2), (x=2, m=5)],
+            [(test="b", x=2, z=1.0)]),
+        3 => ([(x=3, y="h", z="d")],
+            NamedTuple{(:x, :m),Tuple{Int64,Int64}}[],
+            [(test="h", x=3, z=1.0)]),
+        4 => ([(x=4, y="c", z="i"), (x=4, y="d", z="h"), (x=4, y="g", z="e"), (x=4, y="k", z="a")],
+            [(x=4, m=6)],
+            [(test="d", x=4, z=1.0), (test="k", x=4, z=1.0)]),
+        5 => ([(x=5, y="f", z="f"), (x=5, y="j", z="b")],
+            [(x=5, m=4)],
+            [(test="f", x=5, z=1.0), (test="j", x=5, z=1.0)]),
+        "gotcha" => (NamedTuple{(:x, :y, :z),NTuple{3,Any}}[],
+            NamedTuple{(:x, :m),NTuple{2,Any}}[],
+            [(test="e", x="gotcha", z=1.0)]))
     @test g == expected
     @test keys(dfg) == keys(expected)
     @test all(all(dfg[k] .== DataFrame.(expected[k])) for k in keys(dfg))
@@ -123,14 +123,14 @@ end
     @test t == Baz.(Tables.rows(Legolas.read(path)))
     tbl = Arrow.Table(Legolas.tobuffer(t, Schema("baz", 1); metadata=("a" => "b", "c" => "d")))
     @test Set(Arrow.getmetadata(tbl)) == Set((Legolas.LEGOLAS_SCHEMA_QUALIFIED_METADATA_KEY => "baz@1",
-                                              "a" => "b", "c" => "d"))
+        "a" => "b", "c" => "d"))
 
     struct Foo
         meta
     end
     Legolas.Arrow.getmetadata(foo::Foo) = foo.meta
     foo = Foo(Dict("a" => "b", "b" => "b",
-                   Legolas.LEGOLAS_SCHEMA_QUALIFIED_METADATA_KEY => "baz@1"))
+        Legolas.LEGOLAS_SCHEMA_QUALIFIED_METADATA_KEY => "baz@1"))
     @test Legolas.Schema("baz", 1) == Legolas.extract_schema(foo)
 
     t = [(a="a", c=1, b="b"), Baz(a=1, b=2)] # not a valid Tables.jl table
@@ -154,7 +154,7 @@ end
     @test propertynames(r) == (:z, :x, :y)
     @test r === Row(Schema("bar", 1), r)
     @test r === Row(Schema("bar", 1); x=1, y=2, z=3)
-    @test r === Row(Schema("bar", 1), first(Tables.rows(Arrow.Table(Arrow.tobuffer((x=[1],y=[2],z=[3]))))))
+    @test r === Row(Schema("bar", 1), first(Tables.rows(Arrow.Table(Arrow.tobuffer((x=[1], y=[2], z=[3]))))))
     @test r[1] === 3
     @test string(r) == "Row(Schema(\"bar@1\"), (z = 3, x = 1, y = 2))"
 
@@ -164,7 +164,7 @@ end
     long_row = Row(Schema("bar", 1), (x=1, y=2, z=zeros(100, 100)))
     @test length(sprint(show, long_row; context=(:limit => true))) < 200
 
-    @test_throws Legolas.UnknownSchemaError Legolas.transform(Legolas.Schema("imadethisup@3"); a = 1, b = 2)
+    @test_throws Legolas.UnknownSchemaError Legolas.transform(Legolas.Schema("imadethisup@3"); a=1, b=2)
     @test_throws Legolas.UnknownSchemaError Legolas.validate(Tables.Schema((:a, :b), (Int, Int)), Legolas.Schema("imadethisup@3"))
     @test_throws Legolas.UnknownSchemaError Legolas.schema_qualified_string(Legolas.Schema("imadethisup@3"))
 
@@ -176,26 +176,61 @@ end
     @test all(tbl.schema .== schemas)
 end
 
+@testset "schema field name and type tests" begin
+    Parent = @row("parent@1",
+                  first_parent_field::Int=1,
+                  second_parent_field::String="second")
+
+    parent_fields = (:first_parent_field, :second_parent_field)
+    parent_field_types = (Int, String)
+    
+    @test Legolas.schema_field_names(Schema{:parent,1}) == parent_fields
+    @test Legolas.schema_field_names(Schema("parent@1")) == parent_fields
+    @test Legolas.schema_field_names(Row(Schema("parent@1"), (;))) == parent_fields
+
+    @test Legolas.schema_field_types(Schema{:parent,1}) == parent_field_types
+    @test Legolas.schema_field_types(Schema("parent@1")) == parent_field_types
+    @test Legolas.schema_field_types(Row(Schema("parent@1"), (;))) == parent_field_types
+
+    Child = @row("child@1" > "parent@1",
+                  first_child_field::Symbol=:first,
+                  second_child_field="I can be anything")
+
+    child_fields = (:first_child_field, :second_child_field, parent_fields...)
+    child_field_types = (Symbol, Any, parent_field_types...)
+
+    @test Legolas.schema_field_names(Schema{:child,1}) == child_fields
+    @test Legolas.schema_field_names(Schema("child@1")) == child_fields
+    @test Legolas.schema_field_names(Row(Schema("child@1"), (;))) == child_fields
+
+    @test Legolas.schema_field_types(Schema{:child,1}) == child_field_types
+    @test Legolas.schema_field_types(Schema("child@1")) == child_field_types
+    @test Legolas.schema_field_types(Row(Schema("child@1"), (;))) == child_field_types
+
+    @test_throws Legolas.UnknownSchemaError Legolas.schema_field_names(Legolas.Schema("imadethisup@3"))
+    @test_throws Legolas.UnknownSchemaError Legolas.schema_field_types(Legolas.Schema("imadethisup@3"))
+end
+
 @testset "isequal, hash" begin
     TestRow = @row("testrow@1", x, y)
 
-    foo = TestRow(; x = [1])
-    foo2 = TestRow(; x = [1])
+    foo = TestRow(; x=[1])
+    foo2 = TestRow(; x=[1])
     @test isequal(foo, foo2)
     @test hash(foo) == hash(foo2)
 
-    foo3 = TestRow(; x = [3])
+    foo3 = TestRow(; x=[3])
     @test !isequal(foo, foo3)
     @test hash(foo) != hash(foo3)
 end
 
-const MyInnerRow = @row("my-inner-schema@1", b::Int=1)
+const MyInnerRow = @row("my-inner-schema@1", b::Int = 1)
 const MyOuterRow = @row("my-outer-schema@1",
-                        a::String,
-                        x::MyInnerRow=MyInnerRow(x))
+    a::String,
+    x::MyInnerRow = MyInnerRow(x))
 
 @testset "Nested arrow serialization" begin
-    table = [MyOuterRow(; a="outer_a", x = MyInnerRow())]
+    table = [MyOuterRow(; a="outer_a", x=MyInnerRow())]
     roundtripped_table = Legolas.read(Legolas.tobuffer(table, Legolas.Schema("my-outer-schema@1")))
     @test table == MyOuterRow.(Tables.rows(roundtripped_table))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,64 +42,64 @@ end
 
 @testset "Legolas.location" begin
     collections = (['a', 'b', 'c', 'f', 'b'],
-        ['d', 'c', 'e', 'b'],
-        ['f', 'a', 'f'])
+                   ['d', 'c', 'e', 'b'],
+                   ['f', 'a', 'f'])
     expected = Dict('f' => ([4], [], [1, 3]),
-        'a' => ([1], [], [2]),
-        'c' => ([3], [2], []),
-        'd' => ([], [1], []),
-        'e' => ([], [3], []),
-        'b' => ([2, 5], [4], []))
+                    'a' => ([1], [], [2]),
+                    'c' => ([3], [2], []),
+                    'd' => ([], [1], []),
+                    'e' => ([], [3], []),
+                    'b' => ([2, 5], [4], []))
     @test Legolas.locations(collections) == expected
 end
 
 @testset "Legolas.gather" begin
     a = [(x=1, y="a", z="k"),
-        (x=2, y="b", z="j"),
-        (x=4, y="c", z="i"),
-        (x=4, y="d", z="h"),
-        (x=2, y="e", z="g"),
-        (x=5, y="f", z="f"),
-        (x=4, y="g", z="e"),
-        (x=3, y="h", z="d"),
-        (x=1, y="i", z="c"),
-        (x=5, y="j", z="b"),
-        (x=4, y="k", z="a")]
+         (x=2, y="b", z="j"),
+         (x=4, y="c", z="i"),
+         (x=4, y="d", z="h"),
+         (x=2, y="e", z="g"),
+         (x=5, y="f", z="f"),
+         (x=4, y="g", z="e"),
+         (x=3, y="h", z="d"),
+         (x=1, y="i", z="c"),
+         (x=5, y="j", z="b"),
+         (x=4, y="k", z="a")]
     b = [(x=1, m=1),
-        (x=2, m=2),
-        (x=2, m=5),
-        (x=5, m=4),
-        (x=4, m=6)]
+         (x=2, m=2),
+         (x=2, m=5),
+         (x=5, m=4),
+         (x=4, m=6)]
     c = [(test="a", x=1, z=1.0),
-        (test="b", x=2, z=1.0),
-        (test="d", x=4, z=1.0),
-        (test="e", x="gotcha", z=1.0),
-        (test="f", x=5, z=1.0),
-        (test="h", x=3, z=1.0),
-        (test="i", x=1, z=1.0),
-        (test="j", x=5, z=1.0),
-        (test="k", x=4, z=1.0)]
+         (test="b", x=2, z=1.0),
+         (test="d", x=4, z=1.0),
+         (test="e", x="gotcha", z=1.0),
+         (test="f", x=5, z=1.0),
+         (test="h", x=3, z=1.0),
+         (test="i", x=1, z=1.0),
+         (test="j", x=5, z=1.0),
+         (test="k", x=4, z=1.0)]
     dfa, dfb, dfc = DataFrame(a), DataFrame(b), DataFrame(c)
     g = Legolas.gather(:x, a, b, c; extract=(t, i) -> t[i])
     dfg = Legolas.gather(:x, dfa, dfb, dfc)
     expected = Dict(1 => ([(x=1, y="a", z="k"), (x=1, y="i", z="c")],
-            [(x=1, m=1)],
-            [(test="a", x=1, z=1.0), (test="i", x=1, z=1.0)]),
-        2 => ([(x=2, y="b", z="j"), (x=2, y="e", z="g")],
-            [(x=2, m=2), (x=2, m=5)],
-            [(test="b", x=2, z=1.0)]),
-        3 => ([(x=3, y="h", z="d")],
-            NamedTuple{(:x, :m),Tuple{Int64,Int64}}[],
-            [(test="h", x=3, z=1.0)]),
-        4 => ([(x=4, y="c", z="i"), (x=4, y="d", z="h"), (x=4, y="g", z="e"), (x=4, y="k", z="a")],
-            [(x=4, m=6)],
-            [(test="d", x=4, z=1.0), (test="k", x=4, z=1.0)]),
-        5 => ([(x=5, y="f", z="f"), (x=5, y="j", z="b")],
-            [(x=5, m=4)],
-            [(test="f", x=5, z=1.0), (test="j", x=5, z=1.0)]),
-        "gotcha" => (NamedTuple{(:x, :y, :z),NTuple{3,Any}}[],
-            NamedTuple{(:x, :m),NTuple{2,Any}}[],
-            [(test="e", x="gotcha", z=1.0)]))
+                          [(x=1, m=1)],
+                          [(test="a", x=1, z=1.0), (test="i", x=1, z=1.0)]),
+                    2 => ([(x=2, y="b", z="j"), (x=2, y="e", z="g")],
+                          [(x=2, m=2), (x=2, m=5)],
+                          [(test="b", x=2, z=1.0)]),
+                    3 => ([(x=3, y="h", z="d")],
+                          NamedTuple{(:x, :m),Tuple{Int64,Int64}}[],
+                          [(test="h", x=3, z=1.0)]),
+                    4 => ([(x=4, y="c", z="i"), (x=4, y="d", z="h"), (x=4, y="g", z="e"), (x=4, y="k", z="a")],
+                          [(x=4, m=6)],
+                          [(test="d", x=4, z=1.0), (test="k", x=4, z=1.0)]),
+                    5 => ([(x=5, y="f", z="f"), (x=5, y="j", z="b")],
+                          [(x=5, m=4)],
+                          [(test="f", x=5, z=1.0), (test="j", x=5, z=1.0)]),
+                    "gotcha" => (NamedTuple{(:x, :y, :z),NTuple{3,Any}}[],
+                                 NamedTuple{(:x, :m),NTuple{2,Any}}[],
+                                 [(test="e", x="gotcha", z=1.0)]))
     @test g == expected
     @test keys(dfg) == keys(expected)
     @test all(all(dfg[k] .== DataFrame.(expected[k])) for k in keys(dfg))
@@ -123,14 +123,14 @@ end
     @test t == Baz.(Tables.rows(Legolas.read(path)))
     tbl = Arrow.Table(Legolas.tobuffer(t, Schema("baz", 1); metadata=("a" => "b", "c" => "d")))
     @test Set(Arrow.getmetadata(tbl)) == Set((Legolas.LEGOLAS_SCHEMA_QUALIFIED_METADATA_KEY => "baz@1",
-        "a" => "b", "c" => "d"))
+                                              "a" => "b", "c" => "d"))
 
     struct Foo
         meta
     end
     Legolas.Arrow.getmetadata(foo::Foo) = foo.meta
     foo = Foo(Dict("a" => "b", "b" => "b",
-        Legolas.LEGOLAS_SCHEMA_QUALIFIED_METADATA_KEY => "baz@1"))
+                   Legolas.LEGOLAS_SCHEMA_QUALIFIED_METADATA_KEY => "baz@1"))
     @test Legolas.Schema("baz", 1) == Legolas.extract_schema(foo)
 
     t = [(a="a", c=1, b="b"), Baz(a=1, b=2)] # not a valid Tables.jl table
@@ -228,10 +228,10 @@ end
     @test hash(foo) != hash(foo3)
 end
 
-const MyInnerRow = @row("my-inner-schema@1", b::Int = 1)
+const MyInnerRow = @row("my-inner-schema@1", b::Int=1)
 const MyOuterRow = @row("my-outer-schema@1",
-    a::String,
-    x::MyInnerRow = MyInnerRow(x))
+                        a::String,
+                        x::MyInnerRow = MyInnerRow(x))
 
 @testset "Nested arrow serialization" begin
     table = [MyOuterRow(; a="outer_a", x=MyInnerRow())]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,11 +186,11 @@ end
     
     @test Legolas.schema_field_names(Schema{:parent,1}) == parent_fields
     @test Legolas.schema_field_names(Schema("parent@1")) == parent_fields
-    @test Legolas.schema_field_names(Row(Schema("parent@1"), (;))) == parent_fields
+    @test Legolas.schema_field_names(Parent()) == parent_fields
 
     @test Legolas.schema_field_types(Schema{:parent,1}) == parent_field_types
     @test Legolas.schema_field_types(Schema("parent@1")) == parent_field_types
-    @test Legolas.schema_field_types(Row(Schema("parent@1"), (;))) == parent_field_types
+    @test Legolas.schema_field_types(Parent()) == parent_field_types
 
     Child = @row("child@1" > "parent@1",
                   first_child_field::Symbol=:first,
@@ -201,11 +201,11 @@ end
 
     @test Legolas.schema_field_names(Schema{:child,1}) == child_fields
     @test Legolas.schema_field_names(Schema("child@1")) == child_fields
-    @test Legolas.schema_field_names(Row(Schema("child@1"), (;))) == child_fields
+    @test Legolas.schema_field_names(Child()) == child_fields
 
     @test Legolas.schema_field_types(Schema{:child,1}) == child_field_types
     @test Legolas.schema_field_types(Schema("child@1")) == child_field_types
-    @test Legolas.schema_field_types(Row(Schema("child@1"), (;))) == child_field_types
+    @test Legolas.schema_field_types(Child()) == child_field_types
 
     @test_throws Legolas.UnknownSchemaError Legolas.schema_field_names(Legolas.Schema("imadethisup@3"))
     @test_throws Legolas.UnknownSchemaError Legolas.schema_field_types(Legolas.Schema("imadethisup@3"))


### PR DESCRIPTION
This PR addresses #41. It adds two functions:
```
    schema_field_names(::Type{<:Legolas.Schema})

Get a tuple with the names of the fields of this `Legolas.Schema`, including names that
have been inherited from this `Legolas.Schema`'s parent schema.
```
```
    schema_field_types(::Legolas.Schema{name,version})

Get a tuple with the types of the fields of this `Legolas.Schema`, including types of fields that
have been inherited from this `Legolas.Schema`'s parent schema.
```

Tests have been added to make sure these functions behave like we expect.

```julia

Parent = @row("parent@1",
              first_parent_field::Int=1,
              second_parent_field::String="second")

# returns (:first_parent_field, :second_parent_field)
Legolas.schema_field_names(Legolas.Schema{:parent,1}) 
Legolas.schema_field_names(Legolas.Schema("parent@1"))
Legolas.schema_field_names(Parent())
Legolas.schema_field_names(Parent)

# returns (Int, String)
Legolas.schema_field_types(Schema{:parent,1})
Legolas.schema_field_types(Schema("parent@1"))
Legolas.schema_field_types(Parent())
Legolas.schema_field_types(Parent)
```

This includes tests for schema inheritance as well:
```julia
Child = @row("child@1" > "parent@1",
              first_child_field::Symbol=:first,
              second_child_field="I can be anything")

# returns (:first_child_field, :second_child_field, :first_parent_field, :second_parent_field)
Legolas.schema_field_names(Child) 

# returns (Symbol, Any, Int, String)
Legolas.schema_field_types(Child)
```