### PR TITLE
add missing docstring for Legolas.accepted_field_type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,6 +26,7 @@ Legolas.declared
 Legolas.find_violation
 Legolas.complies_with
 Legolas.validate
+Legolas.accepted_field_type
 ```
 
 ## Validating/Writing/Reading Legolas Tables

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -216,7 +216,29 @@ Arrow.ArrowTypes.fromarrow(::Type{<:SchemaVersion}, id) = first(parse_identifier
 ##### `Tables.Schema` validation
 #####
 
-@inline accepted_field_type(::SchemaVersion, T) = T
+"""
+    Legolas.accepted_field_type(sv::Legolas.SchemaVersion, T::Type)
+
+Return the "maximal supertype" of `T` that is accepted by `sv` when evaluating a
+field of type `>:T` for schematic compliance via [`Legolas.find_violation`](@ref);
+see that function's docstring for an explanation of this function's use in context.
+
+`SchemaVersion` authors may overload this function to broaden particular type
+constraints that determine schematic compliance for their `SchemaVersion`, without
+needing to broaden the type constraints employed by their `SchemaVersion`'s
+record type.
+
+Legolas itself defines the following default overloads:
+
+    accepted_field_type(::SchemaVersion, T::Type) = T
+    accepted_field_type(::SchemaVersion, ::Type{UUID}) = Union{UUID,UInt128}
+    accepted_field_type(::SchemaVersion, ::Type{Symbol}) = Union{Symbol,String}
+
+Outside of these default overloads, this function should only be overloaded against specific
+`SchemaVersion`s that are authored within the same module as the overload definition; to do
+otherwise constitutes type piracy and should be avoided.
+"""
+@inline accepted_field_type(::SchemaVersion, T::Type) = T
 accepted_field_type(::SchemaVersion, ::Type{UUID}) = Union{UUID,UInt128}
 accepted_field_type(::SchemaVersion, ::Type{Symbol}) = Union{Symbol,String}
 


### PR DESCRIPTION
This also tightens the fallback type constraint on `T` from `Any` to `Type`. I don't view this a breaking change since this function would make no sense with non-type arguments anyway (if being passed non-type arguments, there's probably a silent bug happening elsewhere anyway...), but if controversial, i can just remove that part