### PR TITLE
Support attaching docstrings to schema versions

### DIFF
--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -711,6 +711,7 @@ macro version(record_type, required_fields_block)
             elseif parent isa Legolas.SchemaVersion && !(Legolas._has_valid_child_field_types($declared_field_names_types, Legolas.required_fields(parent)))
                 throw(SchemaVersionDeclarationError("declared field types violate parent's field types"))
             else
+                Base.@__doc__($(Base.Meta.quot(record_type)))
                 $(esc(:eval))(Legolas._generate_schema_version_definitions(schema_version, parent, $declared_field_names_types, schema_version_declaration))
                 $(esc(:eval))(Legolas._generate_validation_definitions(schema_version))
                 $(esc(:eval))(Legolas._generate_record_type_definitions(schema_version, $(Base.Meta.quot(record_type))))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -230,6 +230,17 @@ end
     x::Int
 end
 
+@schema "test.documented" Documented
+
+"""
+    DocumentedV1
+
+Very detailed documentation.
+"""
+@version DocumentedV1 begin
+    x
+end
+
 @testset "`Legolas.@version` and associated utilities for declared `Legolas.SchemaVersion`s" begin
     @testset "Legolas.SchemaVersionDeclarationError" begin
         @test_throws SchemaVersionDeclarationError("malformed or missing declaration of required fields") eval(:(@version(NewV1, $(Expr(:block, LineNumberNode(1, :test))))))
@@ -368,6 +379,11 @@ end
     roundtripped = Legolas.read(Legolas.tobuffer(tbl, NestedAgainV1SchemaVersion()))
     @test roundtripped.n[1] == NestedV1(; gc=GrandchildV1(r0_roundtripped), k="test")
     @test roundtripped.h[1] == 3
+
+    @testset "docstring support" begin
+        ds = Docs.docstr(Docs.Binding(@__MODULE__, :DocumentedV1))
+        @test contains(first(ds.text), "Very detailed documentation")
+    end
 end
 
 @testset "miscellaneous Legolas/src/tables.jl tests" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -381,8 +381,8 @@ end
     @test roundtripped.h[1] == 3
 
     @testset "docstring support" begin
-        ds = Docs.docstr(Docs.Binding(@__MODULE__, :DocumentedV1))
-        @test contains(first(ds.text), "Very detailed documentation")
+        ds = string(@doc DocumentedV1)
+        @test contains(ds, "Very detailed documentation")
     end
 end
 


### PR DESCRIPTION
Adds support for attaching docstrings to schema versions. I also attempted to also add support to `@schema` but it wasn't clear what construct the docstring should be attached to.

Fixes: #10 