### PR TITLE
add `record_type` and `schema_version_from_record`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,6 +22,8 @@ Legolas.identifier
 Legolas.parent
 Legolas.required_fields
 Legolas.declaration
+Legolas.record_type
+Legolas.schema_version_from_record
 Legolas.declared
 Legolas.find_violation
 Legolas.complies_with

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -338,6 +338,13 @@ end
                                                                                                         RequiredFieldInfo(:y, :String, false, :(y::String = string(y[1:2])))])
     end
 
+    @testset "Legolas.record_type" begin
+        @test_throws Legolas.UnknownSchemaVersionError(undeclared) Legolas.record_type(undeclared)
+        @test Legolas.record_type(ParentV1SchemaVersion()) == ParentV1
+        @test Legolas.record_type(ChildV1SchemaVersion()) == ChildV1
+        @test Legolas.record_type(GrandchildV1SchemaVersion()) == GrandchildV1
+    end
+
     r0 = (x=[42], y="foo", z=:three, a=1.3)
     r0_arrow = first(Tables.rows(Arrow.Table(Arrow.tobuffer([r0]))))
 
@@ -352,6 +359,10 @@ end
     @test NamedTuple(GrandchildV1(r0)) == (x=[42], y="fo", z=:three, a=1)
     @test GrandchildV1(r0) == GrandchildV1(; r0.x, r0.y, r0.z, r0.a)
     @test GrandchildV1(r0) == GrandchildV1(r0_arrow)
+
+    @test Legolas.schema_version_from_record(ParentV1(r0)) == ParentV1SchemaVersion()
+    @test Legolas.schema_version_from_record(ChildV1(r0)) == ChildV1SchemaVersion()
+    @test Legolas.schema_version_from_record(GrandchildV1(r0)) == GrandchildV1SchemaVersion()
 
     tbl = Arrow.Table(Arrow.tobuffer((; x=[ParentV1(r0)])))
     @test tbl.x[1] == ParentV1(Tables.rowmerge(r0))


### PR DESCRIPTION
These are useful for building semi-generic functionality/harnesses atop suites of known `Legolas.SchemaVersion`s.

Note that this purposefully does NOT define/expose a function like  `schema_version_from_record_type(::Type{T<:AbstractRecord})::SchemaVersion` (though there is an underscore-prefixed function like this that Legolas needs for its own internal codegen usage). We do not intend on exposing this kind of function for reasons similar to those articulated [here](https://github.com/beacon-biosignals/Legolas.jl/pull/29#discussion_r771836108).