### PR TITLE
Use `gensym` for generated type parameters

### DIFF
--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -483,7 +483,7 @@ function _generate_record_type_definitions(schema_version::SchemaVersion, record
         info = get(declared_field_infos, fname, nothing)
         if !isnothing(info)
             if info.parameterize
-                T = Symbol("_", string(fname, "_T"))
+                T = gensym(string(fname, "_T"))
                 push!(type_param_defs, :($T <: $(info.type)))
                 push!(names_of_parameterized_fields, fname)
                 fdef = :($fname::$T)


### PR DESCRIPTION
Fixes an extremely unlikely case where a user would define a field with the same name we generate for the type parameters:
```julia
julia> using Legolas: Legolas, @schema, @version

julia> @schema "demo" Demo

julia> @version DemoV1 begin
           x::(<:String)
           _x_T::String
       end
ERROR: syntax: function argument and static parameter names must be distinct around /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:569
Stacktrace:
 [1] top-level scope
   @ none:1
 [2] eval
   @ ./boot.jl:368 [inlined]
 [3] eval(x::Expr)
   @ Base.MainInclude ./client.jl:478
 [4] top-level scope
   @ ~/.julia/dev/Legolas/src/schemas.jl:737
```