### PR TITLE
Simplify non-parametric constructor on parameterized record types

### DIFF
--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -530,13 +530,11 @@ function _generate_record_type_definitions(schema_version::SchemaVersion, record
                 $(field_assignments...)
                 return new{$(type_param_names...)}($(keys(record_fields)...))
             end
-            function $R(; $(field_kwargs...))
-                $parent_record_application
-                $(field_assignments...)
-                return new{$((:(typeof($n)) for n in names_of_parameterized_fields)...)}($(keys(record_fields)...))
-            end
         end
         outer_constructor_definitions = quote
+            function $R(; $(field_kwargs...))
+                return $R{$((:(typeof($n)) for n in names_of_parameterized_fields)...)}($(keys(record_fields)...))
+            end
             $outer_constructor_definitions
             $R{$(type_param_names...)}(row) where {$(type_param_names...)} = $R{$(type_param_names...)}(; $(kwargs_from_row...))
         end

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -533,7 +533,7 @@ function _generate_record_type_definitions(schema_version::SchemaVersion, record
         end
         outer_constructor_definitions = quote
             function $R(; $(field_kwargs...))
-                return $R{$((:(typeof($n)) for n in names_of_parameterized_fields)...)}($(keys(record_fields)...))
+                return $R{$((:(typeof($n)) for n in names_of_parameterized_fields)...)}(; $(keys(record_fields)...))
             end
             $outer_constructor_definitions
             $R{$(type_param_names...)}(row) where {$(type_param_names...)} = $R{$(type_param_names...)}(; $(kwargs_from_row...))


### PR DESCRIPTION
When creating the inner constructors for Legolas records we'd previously just duplicate most of the functionality of the constructors:
```julia
julia> using Legolas: Legolas, @schema, @version

julia> @schema "demo" Demo

julia> @version DemoV1 begin
          a::(<:String) = coalesce(a, String('a':'z'))
          b::Int64 = coalesce(b, typemax(Int64))
          c::UInt64 = coalesce(c, typemax(UInt64))
          d::Char = begin
              d in ('a', 'b', 'c') ? d : throw(ArgumentError("Invalid d"))
          end
       end

julia> Legolas._generate_record_type_definitions(DemoV1SchemaVersion(), :DemoV1)
quote
    #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:568 =#
    const DemoV1SchemaVersion = $(Expr(:quote, Legolas.SchemaVersion{:demo, 1}))
    #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:569 =#
    struct DemoV1{_a_T <: String} <: (Legolas).AbstractRecord
        #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:570 =#
        a::_a_T
        b::$(Expr(:quote, Int64))
        c::$(Expr(:quote, UInt64))
        d::$(Expr(:quote, Char))
        #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:571 =#
        begin
            #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:528 =#
            function DemoV1{_a_T}(; a = missing, b = missing, c = missing, d = missing) where _a_T
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:528 =#
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:529 =#
                nothing
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:530 =#
                a = coalesce(a, String('a':'z'))
                b = convert($(Expr(:quote, Int64)), coalesce(b, typemax(Int64)))::$(Expr(:quote, Int64))
                c = convert($(Expr(:quote, UInt64)), coalesce(c, typemax(UInt64)))::$(Expr(:quote, UInt64))
                d = convert($(Expr(:quote, Char)), begin
                                #= REPL[3]:6 =#
                                if d in ('a', 'b', 'c')
                                    d
                                else
                                    throw(ArgumentError("Invalid d"))
                                end
                            end)::$(Expr(:quote, Char))
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:531 =#
                return new{_a_T}(a, b, c, d)
            end
            #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:533 =#
            function DemoV1(; a = missing, b = missing, c = missing, d = missing)
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:533 =#
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:534 =#
                nothing
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:535 =#
                a = coalesce(a, String('a':'z'))
                b = convert($(Expr(:quote, Int64)), coalesce(b, typemax(Int64)))::$(Expr(:quote, Int64))
                c = convert($(Expr(:quote, UInt64)), coalesce(c, typemax(UInt64)))::$(Expr(:quote, UInt64))
                d = convert($(Expr(:quote, Char)), begin
                                #= REPL[3]:6 =#
                                if d in ('a', 'b', 'c')
                                    d
                                else
                                    throw(ArgumentError("Invalid d"))
                                end
                            end)::$(Expr(:quote, Char))
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:536 =#
                return new{typeof(a)}(a, b, c, d)
            end
        end
    end
    #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:573 =#
    begin
        #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:540 =#
        DemoV1(row) = begin
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:516 =#
                DemoV1(; a = get(row, :a, missing), b = get(row, :b, missing), c = get(row, :c, missing), d = get(row, :d, missing))
            end
        #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:541 =#
        (DemoV1{_a_T}(row) where _a_T) = begin
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:541 =#
                DemoV1{_a_T}(; a = get(row, :a, missing), b = get(row, :b, missing), c = get(row, :c, missing), d = get(row, :d, missing))
            end
    end
    ...
```
With this PR we instead have the non-parametric constructor call the parametric constructor which results in us not having to have duplicate logic between the constructors:
```julia
julia> using Legolas: Legolas, @schema, @version

julia> @schema "demo" Demo

julia> @version DemoV1 begin
           a::(<:String) = coalesce(a, String('a':'z'))
           b::Int64 = coalesce(b, typemax(Int64))
           c::UInt64 = coalesce(c, typemax(UInt64))
           d::Char = begin
               d in ('a', 'b', 'c') ? d : throw(ArgumentError("Invalid d"))
           end
       end

julia> Legolas._generate_record_type_definitions(DemoV1SchemaVersion(), :DemoV1)
quote
    #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:566 =#
    const DemoV1SchemaVersion = $(Expr(:quote, Legolas.SchemaVersion{:demo, 1}))
    #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:567 =#
    struct DemoV1{_a_T <: String} <: (Legolas).AbstractRecord
        #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:568 =#
        a::_a_T
        b::$(Expr(:quote, Int64))
        c::$(Expr(:quote, UInt64))
        d::$(Expr(:quote, Char))
        #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:569 =#
        begin
            #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:528 =#
            function DemoV1{_a_T}(; a = missing, b = missing, c = missing, d = missing) where _a_T
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:528 =#
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:529 =#
                nothing
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:530 =#
                a = coalesce(a, String('a':'z'))
                b = convert($(Expr(:quote, Int64)), coalesce(b, typemax(Int64)))::$(Expr(:quote, Int64))
                c = convert($(Expr(:quote, UInt64)), coalesce(c, typemax(UInt64)))::$(Expr(:quote, UInt64))
                d = convert($(Expr(:quote, Char)), begin
                                #= REPL[3]:6 =#
                                if d in ('a', 'b', 'c')
                                    d
                                else
                                    throw(ArgumentError("Invalid d"))
                                end
                            end)::$(Expr(:quote, Char))
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:531 =#
                return new{_a_T}(a, b, c, d)
            end
        end
    end
    #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:571 =#
    begin
        #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:535 =#
        function DemoV1(; a = missing, b = missing, c = missing, d = missing)
            #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:535 =#
            #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:536 =#
            return DemoV1{typeof(a)}(; a, b, c, d)
        end
        #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:538 =#
        DemoV1(row) = begin
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:516 =#
                DemoV1(; a = get(row, :a, missing), b = get(row, :b, missing), c = get(row, :c, missing), d = get(row, :d, missing))
            end
        #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:539 =#
        (DemoV1{_a_T}(row) where _a_T) = begin
                #= /Users/cvogt/.julia/dev/Legolas/src/schemas.jl:539 =#
                DemoV1{_a_T}(; a = get(row, :a, missing), b = get(row, :b, missing), c = get(row, :c, missing), d = get(row, :d, missing))
            end
    end
    ...
```
Note this change does not impact behaviour at all as there was no logic flaw in duplicating the logic as it was but it did make the expression generated harder to read.