### PR TITLE
Provide nice error messages when constructing record fields

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,14 +10,16 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Arrow = "2"
+Compat = "3.34"
 DataFrames = "1"
 Tables = "1.4"
 julia = "1.6"
 
 [extras]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Test", "DataFrames", "UUIDs"]
+test = ["Compat", "DataFrames", "Test", "UUIDs"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Arrow = "2"
-Compat = "3.34"
+Compat = "3.34, 4"
 DataFrames = "1"
 Tables = "1.4"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.5.7"
+version = "0.5.8"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/examples/tour.jl
+++ b/examples/tour.jl
@@ -133,11 +133,11 @@ fields_with_x = (; fields..., x="x")
 foo = FooV1(; a=1.0, b="hi", d=[1, 2, 3])
 @test isequal(NamedTuple(foo), (a=1.0, b="hi", c=missing, d=[1, 2, 3]))
 
-# Providing the non-compliantly-typed field `d::Int`, inducing a `MethodError`:
-@test_throws MethodError FooV1(; a=1.0, b="hi", d=2)
+# Providing the non-compliantly-typed field `d::Int`, inducing an `ArgumentError`:
+@test_throws ArgumentError FooV1(; a=1.0, b="hi", d=2)
 
-# Implicitly providing the non-compliantly-typed field `d::Missing`, inducing a `MethodError`:
-@test_throws MethodError FooV1(; a=1.0, b="hi")
+# Implicitly providing the non-compliantly-typed field `d::Missing`, inducing an `ArgumentError`:
+@test_throws ArgumentError FooV1(; a=1.0, b="hi")
 
 #####
 ##### Custom Field Assignments
@@ -243,7 +243,7 @@ end
 # assignments before applying the child's field assignments. Notice how `BazV1` applies the
 # constraints/transformations of both `example.baz@1` and `example.bar@1`:
 @test NamedTuple(BazV1(; x=200, y=:hi)) == (x=127, y="hi", z="hi_127", k=6)
-@test_throws MethodError BazV1(; y=:hi) # `example.baz@1` does not allow `x::Missing`
+@test_throws ArgumentError BazV1(; y=:hi) # `example.baz@1` does not allow `x::Missing`
 
 # `BazV1`'s inner constructor definition is roughly equivalent to:
 #

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -485,9 +485,9 @@ function _generate_record_type_definitions(schema_version::SchemaVersion, record
         if !isnothing(info)
             fcatch = quote
                 if $fname isa $(info.type)
-                    throw(ArgumentError("Invalid value set for field $($fsym) ($(repr($(fname))))"))
+                    throw(ArgumentError("Invalid value set for field `$($fsym)` ($(repr($(fname))))"))
                 else
-                    throw(ArgumentError("Invalid value set for field $($fsym), expected $($(info.type)), got a value of type $(typeof($fname)) ($(repr($(fname))))"))
+                    throw(ArgumentError("Invalid value set for field `$($fsym)`, expected $($(info.type)), got a value of type $(typeof($fname)) ($(repr($(fname))))"))
                 end
             end
             if info.parameterize
@@ -502,7 +502,7 @@ function _generate_record_type_definitions(schema_version::SchemaVersion, record
                         $fcatch
                     end
                     if !($fname isa $(info.type))
-                        throw(TypeError($(Base.Meta.quot(record_type_symbol)), "field $($fsym)", $(info.type), $fname))
+                        throw(TypeError($(Base.Meta.quot(record_type_symbol)), "field `$($fsym)`", $(info.type), $fname))
                     end
                 end
             else

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -485,7 +485,7 @@ function _generate_record_type_definitions(schema_version::SchemaVersion, record
         if !isnothing(info)
             fcatch = quote
                 if $fname isa $(info.type)
-                    throw(ArgumentError("Invalid value set for field $($fsym), custom field assignment failed for: $(repr($(fname)))"))
+                    throw(ArgumentError("Invalid value set for field $($fsym) ($(repr($(fname))))"))
                 else
                     throw(ArgumentError("Invalid value set for field $($fsym), expected $($(info.type)), got a value of type $(typeof($fname)) ($(repr($(fname))))"))
                 end

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -548,11 +548,13 @@ function _generate_record_type_definitions(schema_version::SchemaVersion, record
                 $(field_assignments...)
                 return new{$(type_param_names...)}($(keys(record_fields)...))
             end
+            function $R(; $(field_kwargs...))
+                $parent_record_application
+                $(field_assignments...)
+                return new{$((:(typeof($n)) for n in names_of_parameterized_fields)...)}($(keys(record_fields)...))
+            end
         end
         outer_constructor_definitions = quote
-            function $R(; $(field_kwargs...))
-                return $R{$((:(typeof($n)) for n in names_of_parameterized_fields)...)}(; $(keys(record_fields)...))
-            end
             $outer_constructor_definitions
             $R{$(type_param_names...)}(row) where {$(type_param_names...)} = $R{$(type_param_names...)}(; $(kwargs_from_row...))
         end

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -738,7 +738,7 @@ macro version(record_type, required_fields_block)
         end
     end
     if !allunique(f.name for f in required_field_infos)
-        msg = string("cannot have duplicate field names in `@version` declaration; recieved: ", [f.name for f in required_field_infos])
+        msg = string("cannot have duplicate field names in `@version` declaration; received: ", [f.name for f in required_field_infos])
         return :(throw(SchemaVersionDeclarationError($msg)))
     end
     declared_field_names_types = Expr(:tuple, (:($(f.name) = $(esc(f.type))) for f in required_field_infos)...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -513,7 +513,7 @@ end
 
         @test length(ex_stack) == 2
         @test sprint(showerror, ex_stack[1].exception) == "ArgumentError: Must be a, b, or c"
-        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field a, expected Union{Missing, String}, got a value of type String (\"invalid\")"
+        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field a, custom field assignment failed for: \"invalid\""
 
         ex_stack = try
             FieldErrorV1(; b="invalid")
@@ -523,7 +523,7 @@ end
 
         @test length(ex_stack) == 2
         @test sprint(showerror, ex_stack[1].exception) == "ArgumentError: Must be a, b, or c"
-        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field b, expected Union{Missing, String}, got a value of type String (\"invalid\")"
+        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field b, custom field assignment failed for: \"invalid\""
 
         ex_stack = try
             FieldErrorV1(; c="3")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Compat: current_exceptions
 using Legolas, Test, DataFrames, Arrow, UUIDs
 using Legolas: SchemaVersion, @schema, @version, SchemaVersionDeclarationError, RequiredFieldInfo
 
@@ -560,7 +561,7 @@ end
     end
 
     @testset "reports modifications" begin
-        msg = "ArgumentError: Invalid value set for field a, expected Integer, got a value of type String (\"foo-bar\")"
-        @test_throws msg FieldErrorV3(; a="foo bar")
+        e = ArgumentError("Invalid value set for field a, expected Integer, got a value of type String (\"foo-bar\")")
+        @test_throws e FieldErrorV3(; a="foo bar")
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -514,7 +514,7 @@ end
 
         @test length(ex_stack) == 2
         @test sprint(showerror, ex_stack[1].exception) == "ArgumentError: Must be a, b, or c"
-        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field a (\"invalid\")"
+        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field `a` (\"invalid\")"
 
         ex_stack = try
             FieldErrorV1(; b="invalid")
@@ -524,7 +524,7 @@ end
 
         @test length(ex_stack) == 2
         @test sprint(showerror, ex_stack[1].exception) == "ArgumentError: Must be a, b, or c"
-        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field b (\"invalid\")"
+        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field `b` (\"invalid\")"
 
         ex_stack = try
             FieldErrorV1(; c="3")
@@ -534,7 +534,7 @@ end
 
         @test length(ex_stack) == 2
         @test startswith(sprint(showerror, ex_stack[1].exception), "MethodError: Cannot `convert` an object of type String to an object of type Integer")
-        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field c, expected Union{Missing, Integer}, got a value of type String (\"3\")"
+        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field `c`, expected Union{Missing, Integer}, got a value of type String (\"3\")"
 
         ex_stack = try
             FieldErrorV1(; d=4.0)
@@ -543,7 +543,7 @@ end
         end
 
         @test length(ex_stack) == 1
-        @test sprint(showerror, ex_stack[1].exception) == "TypeError: in FieldErrorV1, in field d, expected Union{Missing, Integer}, got a value of type Float64"
+        @test sprint(showerror, ex_stack[1].exception) == "TypeError: in FieldErrorV1, in field `d`, expected Union{Missing, Integer}, got a value of type Float64"
     end
 
     @testset "one-time evaluation" begin
@@ -561,7 +561,7 @@ end
     end
 
     @testset "reports modifications" begin
-        e = ArgumentError("Invalid value set for field a, expected Integer, got a value of type String (\"foo-bar\")")
+        e = ArgumentError("Invalid value set for field `a`, expected Integer, got a value of type String (\"foo-bar\")")
         @test_throws e FieldErrorV3(; a="foo bar")
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -267,6 +267,7 @@ end
         @test_throws SchemaVersionDeclarationError("provided record type expression is malformed: BobV1 > DaveV1 > JoeV1") @version(BobV1 > DaveV1 > JoeV1, begin x end)
         @test_throws SchemaVersionDeclarationError("provided record type expression is malformed: BobV1 < DaveV1") @version(BobV1 < DaveV1, begin x end)
         @test_throws SchemaVersionDeclarationError("cannot have duplicate field names in `@version` declaration; received: $([:x, :y, :x, :z])") @version(ChildV2, begin x; y; x; z end)
+        @test_throws SchemaVersionDeclarationError("cannot have field name which start with an underscore in `@version` declaration: $([:_X])") @version(ChildV2, begin x; X; _X end)
         @test_throws SchemaVersionDeclarationError("cannot extend from another version of the same schema") @version(ChildV2 > ChildV1, begin x end)
         @test_throws SchemaVersionDeclarationError("declared field types violate parent's field types") @version(NewV1 > ParentV1, begin y::Int end)
         @test_throws SchemaVersionDeclarationError("declared field types violate parent's field types") @version(NewV1 > ChildV1, begin y::Int end)
@@ -580,7 +581,7 @@ end
         end
 
         @test length(ex_stack) == 1
-        @test contains(sprint(showerror, ex_stack[1].exception), r"TypeError: in FieldErrorV1, in \d+, expected var\"\d+\"<:Union{Missing, String}, got Type{AbstractString}")
+        @test contains(sprint(showerror, ex_stack[1].exception), r"TypeError: in FieldErrorV1, in _B, expected _B<:Union{Missing, String}, got Type{AbstractString}")
     end
 
     @testset "one-time evaluation" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -514,7 +514,7 @@ end
 
         @test length(ex_stack) == 2
         @test sprint(showerror, ex_stack[1].exception) == "ArgumentError: Must be a, b, or c"
-        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field a, custom field assignment failed for: \"invalid\""
+        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field a (\"invalid\")"
 
         ex_stack = try
             FieldErrorV1(; b="invalid")
@@ -524,7 +524,7 @@ end
 
         @test length(ex_stack) == 2
         @test sprint(showerror, ex_stack[1].exception) == "ArgumentError: Must be a, b, or c"
-        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field b, custom field assignment failed for: \"invalid\""
+        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field b (\"invalid\")"
 
         ex_stack = try
             FieldErrorV1(; c="3")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -266,7 +266,7 @@ end
         @test_throws SchemaVersionDeclarationError("provided record type symbol is malformed: ChildVTwo") @version(ChildVTwo > ParentV2, begin x end)
         @test_throws SchemaVersionDeclarationError("provided record type expression is malformed: BobV1 > DaveV1 > JoeV1") @version(BobV1 > DaveV1 > JoeV1, begin x end)
         @test_throws SchemaVersionDeclarationError("provided record type expression is malformed: BobV1 < DaveV1") @version(BobV1 < DaveV1, begin x end)
-        @test_throws SchemaVersionDeclarationError("cannot have duplicate field names in `@version` declaration; recieved: $([:x, :y, :x, :z])") @version(ChildV2, begin x; y; x; z end)
+        @test_throws SchemaVersionDeclarationError("cannot have duplicate field names in `@version` declaration; received: $([:x, :y, :x, :z])") @version(ChildV2, begin x; y; x; z end)
         @test_throws SchemaVersionDeclarationError("cannot extend from another version of the same schema") @version(ChildV2 > ChildV1, begin x end)
         @test_throws SchemaVersionDeclarationError("declared field types violate parent's field types") @version(NewV1 > ParentV1, begin y::Int end)
         @test_throws SchemaVersionDeclarationError("declared field types violate parent's field types") @version(NewV1 > ChildV1, begin y::Int end)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -412,7 +412,7 @@ end
         @test typeof(ParamV1{Int}(; i=1.0)) === ParamV1{Int}
         @test_throws TypeError ParamV1{Float64}(; i=1)
         @test_throws TypeError ParamV1(; i=1.0)
-        @test_throws InexactError ParamV1{Int}(; i=1.1)
+        @test_throws ArgumentError ParamV1{Int}(; i=1.1)
     end
 end
 
@@ -562,6 +562,25 @@ end
 
         @test length(ex_stack) == 1
         @test sprint(showerror, ex_stack[1].exception) == "TypeError: in FieldErrorV1, in field `d`, expected Union{Missing, Integer}, got a value of type Float64"
+
+        ex_stack = try
+            FieldErrorV1{Missing,Int}(; d=4.5)
+        catch
+            current_exceptions()
+        end
+
+        @test length(ex_stack) == 2
+        @test typeof(ex_stack[1].exception) == InexactError
+        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field `d`, expected Union{Missing, Integer}, got a value of type Float64 (4.5)"
+
+        ex_stack = try
+            FieldErrorV1{AbstractString,Int}
+        catch
+            current_exceptions()
+        end
+
+        @test length(ex_stack) == 1
+        @test contains(sprint(showerror, ex_stack[1].exception), r"TypeError: in FieldErrorV1, in \d+, expected var\"\d+\"<:Union{Missing, String}, got Type{AbstractString}")
     end
 
     @testset "one-time evaluation" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -472,3 +472,95 @@ end
 
 c = ConstrainedFieldV1(field = "1")
 @test c.field == 1
+
+#####
+##### record error reporting
+#####
+
+@schema "test.field-error" FieldError
+
+function _validate(x)
+    x in ("a", "b", "c") || throw(ArgumentError("Must be a, b, or c"))
+    return x
+end
+
+@version FieldErrorV1 begin
+    a::Union{String,Missing} = Legolas.lift(_validate, a)
+    b::(<:Union{String,Missing}) = Legolas.lift(_validate, b)
+    c::Union{Integer,Missing}
+    d::(<:Union{Integer,Missing})
+end
+
+_num_calls = Ref{Int}(0)
+@version FieldErrorV2 begin
+    a::Integer = begin
+        _num_calls[] += 1
+        a isa Function ? a() : a
+    end
+end
+
+@version FieldErrorV3 begin
+    a::Integer = replace(a, ' ' => '-')
+end
+
+@testset "Legolas record constructor error handling" begin
+    @testset "field constructor error" begin
+        ex_stack = try
+            FieldErrorV1(; a="invalid")
+        catch
+            current_exceptions()
+        end
+
+        @test length(ex_stack) == 2
+        @test sprint(showerror, ex_stack[1].exception) == "ArgumentError: Must be a, b, or c"
+        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field a, expected Union{Missing, String}, got a value of type String (\"invalid\")"
+
+        ex_stack = try
+            FieldErrorV1(; b="invalid")
+        catch
+            current_exceptions()
+        end
+
+        @test length(ex_stack) == 2
+        @test sprint(showerror, ex_stack[1].exception) == "ArgumentError: Must be a, b, or c"
+        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field b, expected Union{Missing, String}, got a value of type String (\"invalid\")"
+
+        ex_stack = try
+            FieldErrorV1(; c="3")
+        catch
+            current_exceptions()
+        end
+
+        @test length(ex_stack) == 2
+        @test startswith(sprint(showerror, ex_stack[1].exception), "MethodError: Cannot `convert` an object of type String to an object of type Integer")
+        @test sprint(showerror, ex_stack[2].exception) == "ArgumentError: Invalid value set for field c, expected Union{Missing, Integer}, got a value of type String (\"3\")"
+
+        ex_stack = try
+            FieldErrorV1(; d=4.0)
+        catch
+            current_exceptions()
+        end
+
+        @test length(ex_stack) == 1
+        @test sprint(showerror, ex_stack[1].exception) == "TypeError: in FieldErrorV1, in field d, expected Union{Missing, Integer}, got a value of type Float64"
+    end
+
+    @testset "one-time evaluation" begin
+        _num_calls[] = 0
+        FieldErrorV2(; a=1.0)
+        @test _num_calls[] == 1
+
+        _num_calls[] = 0
+        @test_throws ArgumentError FieldErrorV2(; a=() -> error("foo"))
+        @test _num_calls[] == 1
+
+        _num_calls[] = 0
+        @test_throws ArgumentError FieldErrorV2(; a="a")
+        @test _num_calls[] == 1
+    end
+
+    @testset "reports modifications" begin
+        msg = "ArgumentError: Invalid value set for field a, expected Integer, got a value of type String (\"foo-bar\")"
+        @test_throws msg FieldErrorV3(; a="foo bar")
+    end
+end


### PR DESCRIPTION
Fixes #44 but we'll probably want to spawn a new issue for https://github.com/beacon-biosignals/Legolas.jl/issues/44#issuecomment-1292609205. A quick example of this in action:

```julia
julia> using Legolas: Legolas, @schema, @version

julia> @schema "test.field-error" FieldError

julia> function _validate(x)
           x in ("a", "b", "c") || throw(ArgumentError("Must be a, b, or c"))
           return x
       end
_validate (generic function with 1 method)

julia> @version FieldErrorV1 begin
           a::Union{String,Missing} = Legolas.lift(_validate, a)
           b::(<:Union{String,Missing}) = Legolas.lift(_validate, b)
           c::Union{Integer,Missing}
           d::(<:Union{Integer,Missing})
       end

julia> FieldErrorV1(; a="invalid")
ERROR: ArgumentError: Invalid value set for field `a` ("invalid")
Stacktrace:
 [1] FieldErrorV1(; a::String, b::Missing, c::Missing, d::Missing)
   @ Main ~/.julia/dev/Legolas/src/schemas.jl:488
 [2] top-level scope
   @ REPL[5]:1

caused by: ArgumentError: Must be a, b, or c
Stacktrace:
 [1] _validate
   @ ./REPL[3]:2 [inlined]
 [2] lift
   @ ~/.julia/dev/Legolas/src/lift.jl:12 [inlined]
 [3] FieldErrorV1(; a::String, b::Missing, c::Missing, d::Missing)
   @ Main ~/.julia/dev/Legolas/src/schemas.jl:511
 [4] top-level scope
   @ REPL[5]:1
```
I ended up going with this stacked exception approach as it allows for field constructors to easily report issues without having to include the additional context of the name of the field or the value itself.

Update: Modified example to show current exception output

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204322643598304