### PR TITLE
Add parameterized schema version tests

### DIFF
--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -530,11 +530,13 @@ function _generate_record_type_definitions(schema_version::SchemaVersion, record
                 $(field_assignments...)
                 return new{$(type_param_names...)}($(keys(record_fields)...))
             end
+            function $R(; $(field_kwargs...))
+                $parent_record_application
+                $(field_assignments...)
+                return new{$((:(typeof($n)) for n in names_of_parameterized_fields)...)}($(keys(record_fields)...))
+            end
         end
         outer_constructor_definitions = quote
-            function $R(; $(field_kwargs...))
-                return $R{$((:(typeof($n)) for n in names_of_parameterized_fields)...)}(; $(keys(record_fields)...))
-            end
             $outer_constructor_definitions
             $R{$(type_param_names...)}(row) where {$(type_param_names...)} = $R{$(type_param_names...)}(; $(kwargs_from_row...))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,10 @@ using Legolas: SchemaVersion, @schema, @version, SchemaVersionDeclarationError, 
 
 @test_throws SchemaVersionDeclarationError("no prior `@schema` declaration found in current module") @version(TestV1, begin x end)
 
-include(joinpath(dirname(@__DIR__), "examples", "tour.jl"))
+# Isolate schema defined in the tour from the rest of the tests
+module Tour
+    include(joinpath(dirname(@__DIR__), "examples", "tour.jl"))
+end
 
 @testset "Legolas.lift" begin
     @test ismissing(Legolas.lift(sin, nothing))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -244,6 +244,12 @@ Very detailed documentation.
     x
 end
 
+@schema "test.param" Param
+
+@version ParamV1 begin
+    i::(<:Integer)
+end
+
 @testset "`Legolas.@version` and associated utilities for declared `Legolas.SchemaVersion`s" begin
     @testset "Legolas.SchemaVersionDeclarationError" begin
         @test_throws SchemaVersionDeclarationError("malformed or missing declaration of required fields") eval(:(@version(NewV1, $(Expr(:block, LineNumberNode(1, :test))))))
@@ -397,6 +403,12 @@ end
     @testset "docstring support" begin
         ds = string(@doc DocumentedV1)
         @test contains(ds, "Very detailed documentation")
+    end
+
+    @testset "parameterized" begin
+        @test typeof(ParamV1(i=1)) === ParamV1{Int}
+        @test typeof(ParamV1{Integer}(i=1)) === ParamV1{Integer}
+        @test typeof(ParamV1{Int}(i=1.0)) === ParamV1{Int}
     end
 end
 


### PR DESCRIPTION
Adding additional tests around parameterized schema versions as called out in: https://github.com/beacon-biosignals/Legolas.jl/pull/83#issuecomment-1499524213. I also put the tour tests in a separate namespace to ensure that we don't run into schema version collisions.

These tests required that we rollback #82 so that is also included here.