### PR TITLE
Use `find_violations` in `find_violation`

### DIFF
--- a/examples/tour.jl
+++ b/examples/tour.jl
@@ -76,8 +76,8 @@ for s in [Tables.Schema((:a, :b, :c, :d), (Real, String, Any, AbstractVector)), 
     @test validate(s, FooV1SchemaVersion()) isa Nothing
 
     # if `find_violations` finds any violations, it returns a vector of tuples indicating the relevant
-    # fields and their violations; returns `nothing` otherwise
-    @test isnothing(find_violations(s, FooV1SchemaVersion()))
+    # fields and their violations
+    @test isempty(find_violations(s, FooV1SchemaVersion()))
 end
 
 # ...while the below `Tables.Schema`s do not:

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -263,8 +263,8 @@ See also: [`Legolas.find_violations`](@ref), [`Legolas.validate`](@ref), [`Legol
 """
 function find_violation(ts::Tables.Schema, sv::SchemaVersion)
     Base.depwarn(
-        "The `find_violation` function will be deprecated in a future release. " *
-        "Please use `find_violations(args...)` instead of `find_violation(args...)`.",
+        "`find_violation(ts, sv)` is deprecated, use: `let v = find_violations(ts, sv); " *
+        "isempty(v) ? nothing : v; end` instead.",
         :find_violation,
     )
     violations = find_violations(ts, sv; fail_fast=true)

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -251,6 +251,8 @@ otherwise constitutes type piracy and should be avoided.
 accepted_field_type(::SchemaVersion, ::Type{UUID}) = Union{UUID,UInt128}
 accepted_field_type(::SchemaVersion, ::Type{Symbol}) = Union{Symbol,String}
 
+
+
 """
     Legolas.find_violation(ts::Tables.Schema, sv::Legolas.SchemaVersion)
 
@@ -259,7 +261,15 @@ schema violations, see [`Legolas.find_violations`](@ref).
 
 See also: [`Legolas.find_violations`](@ref), [`Legolas.validate`](@ref), [`Legolas.complies_with`](@ref)
 """
-find_violation(::Tables.Schema, sv::SchemaVersion) = throw(UnknownSchemaVersionError(sv))
+function find_violation(ts::Tables.Schema, sv::SchemaVersion)
+    Base.depwarn(
+        "The `find_violation` function will be deprecated in a future release. " *
+        "Please use `find_violations(args...)` instead of `find_violation(args...)`.",
+        :find_violation,
+    )
+    violations = find_violations(ts, sv; fail_fast=true)
+    return isempty(violations) ? nothing : first(violations)
+end
 
 """
     Legolas.find_violations(ts::Tables.Schema, sv::Legolas.SchemaVersion)
@@ -273,7 +283,9 @@ the expected type `T`, reported as `f::Symbol => T::DataType`.
 
 See also: [`Legolas.validate`](@ref), [`Legolas.complies_with`](@ref)
 """
-find_violations(::Tables.Schema, sv::SchemaVersion) = throw(UnknownSchemaVersionError(sv))
+function find_violations(::Tables.Schema, sv::SchemaVersion; fail_fast::Bool=false)
+    throw(UnknownSchemaVersionError(sv))
+end
 
 """
     Legolas.validate(ts::Tables.Schema, sv::Legolas.SchemaVersion)
@@ -284,7 +296,7 @@ See also: [`Legolas.find_violations`](@ref), [`Legolas.find_violation`](@ref), [
 """
 function validate(ts::Tables.Schema, sv::SchemaVersion)
     results = find_violations(ts, sv)
-    isnothing(results) && return nothing
+    isempty(results) && return nothing
 
     field_err = Symbol[]
     type_err = Tuple{Symbol,Type,Type}[]
@@ -315,7 +327,7 @@ Return `isnothing(find_violations(ts, sv))`.
 
 See also: [`Legolas.find_violations`](@ref), [`Legolas.validate`](@ref)
 """
-complies_with(ts::Tables.Schema, sv::SchemaVersion) = isnothing(find_violations(ts, sv))
+complies_with(ts::Tables.Schema, sv::SchemaVersion) = isempty(find_violations(ts, sv))
 
 #####
 ##### `AbstractRecord`
@@ -464,41 +476,19 @@ end
 
 function _generate_validation_definitions(schema_version::SchemaVersion)
     # When `fail_fast == true`, return first violation found rather than all violations
-    _violation_check = (; fail_fast::Bool) -> begin
-        violations = Expr[]
-        myvector = gensym()
-        push!(violations, :($myvector = Any[]))
-        for (fname, ftype) in pairs(required_fields(schema_version))
-            fname = Base.Meta.quot(fname)
-            push!(violations, quote
-                S = $Legolas.accepted_field_type(sv, $ftype)
-                result = $Legolas._check_for_expected_field(ts, $fname, S)
-                if !isnothing(result) && $(fail_fast)
-                    return $fname => result
-                elseif !isnothing(result)
-                    push!($myvector, ($fname => result))
-                end
-            end)
-        end
-        push!(violations, quote
-            return length($myvector) > 0 ? $myvector : nothing
-        end)
-        return violations
-    end
-
+    SV = Base.Meta.quot(typeof(schema_version))
     return quote
-        function $(Legolas).find_violation(ts::$(Tables).Schema, sv::$(Base.Meta.quot(typeof(schema_version))))
-            Base.depwarn(
-                "The `find_violation` function will be deprecated in a future release. " *
-                "Please use `find_violations(args...)` instead of `find_violation(args...)`.",
-                :find_violation,
-            )
-            $(_violation_check(; fail_fast=true)...)
-        end
-
-        # Multiple violation reporting
-        function $(Legolas).find_violations(ts::$(Tables).Schema, sv::$(Base.Meta.quot(typeof(schema_version))))
-            $(_violation_check(; fail_fast=false)...)
+        function Legolas.find_violations(ts::$(Tables).Schema, sv::$SV; fail_fast::Bool=false)
+            violations = Pair{Symbol,Union{Type,Missing}}[]
+            for (fname, ftype) in pairs(Legolas.required_fields(sv))
+                S = Legolas.accepted_field_type(sv, ftype)
+                result = Legolas._check_for_expected_field(ts, fname, S)
+                if !isnothing(result)
+                    push!(violations, fname => result)
+                    fail_fast && break
+                end
+            end
+            return violations
         end
     end
 end

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -274,8 +274,7 @@ end
 """
     Legolas.find_violations(ts::Tables.Schema, sv::Legolas.SchemaVersion)
 
-Return vector of all schema violations for table `ts` and schema `sv`; otherwise,
-return `nothing`.
+Return vector of all, if any, schema violations for table `ts` and schema `sv`.
 
 A schema violation occurs when a required field `f` of `sv` is not present in `ts`,
 reported as `f::Symbol => missing::Missing`, or when a required field `f` does not match


### PR DESCRIPTION
Updates #85 to generate only `find_violations` methods. Additionally, `find_violations` also returns an empty array when no violations around found, the deprecation now provides guidance on how to update code, and I dropped `fast_fail` as this code isn't performance critical and if it is we may want to return a generator instead.