### PR TITLE
Add `accepted_field_type` for abstract vectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.5.9"
+version = "0.5.10"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -242,6 +242,9 @@ Legolas itself defines the following default overloads:
     accepted_field_type(::SchemaVersion, T::Type) = T
     accepted_field_type(::SchemaVersion, ::Type{UUID}) = Union{UUID,UInt128}
     accepted_field_type(::SchemaVersion, ::Type{Symbol}) = Union{Symbol,String}
+    accepted_field_type(::SchemaVersion, ::Type{Vector{String}}) = AbstractVector{<:AbstractString}
+    accepted_field_type(::SchemaVersion, ::Type{Vector{T}}) where T = AbstractVector{<:T}
+    accepted_field_type(::SchemaVersion, ::Type{Vector}) = AbstractVector
 
 Outside of these default overloads, this function should only be overloaded against specific
 `SchemaVersion`s that are authored within the same module as the overload definition; to do
@@ -250,6 +253,9 @@ otherwise constitutes type piracy and should be avoided.
 @inline accepted_field_type(::SchemaVersion, T::Type) = T
 accepted_field_type(::SchemaVersion, ::Type{UUID}) = Union{UUID,UInt128}
 accepted_field_type(::SchemaVersion, ::Type{Symbol}) = Union{Symbol,String}
+accepted_field_type(::SchemaVersion, ::Type{Vector{String}}) = AbstractVector{<:AbstractString}
+accepted_field_type(::SchemaVersion, ::Type{Vector{T}}) where T = AbstractVector{<:T}
+accepted_field_type(::SchemaVersion, ::Type{Vector}) = AbstractVector
 
 """
     Legolas.find_violation(ts::Tables.Schema, sv::Legolas.SchemaVersion)
@@ -273,7 +279,7 @@ find_violation(::Tables.Schema, sv::SchemaVersion) = throw(UnknownSchemaVersionE
 
 Return a `Vector{Pair{Symbol,Union{Type,Missing}}}` of all of `ts`'s violations with respect to `sv`.
 
-This function's notion of "violation" is defined by [`Legolas.find_violation`](@ref), which immediately returns the first violation found; prefer to use that function instead of `find_violations` in situations where you only need to detect *any* violation instead of *all* violations. 
+This function's notion of "violation" is defined by [`Legolas.find_violation`](@ref), which immediately returns the first violation found; prefer to use that function instead of `find_violations` in situations where you only need to detect *any* violation instead of *all* violations.
 
 See also: [`Legolas.validate`](@ref), [`Legolas.complies_with`](@ref), [`Legolas.find_violation`](@ref).
 """


### PR DESCRIPTION
ref https://github.com/apache/arrow-julia/issues/452

Add `accepted_field_type`s as proposed by @ericphanson in above issue. No additional tests added BUT `main` is currently failing when run on latest (v2.6) Arrow.jl (e.g. in #88), and no longer fails with this fix.