### PR TITLE
fix quoting issue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.5.10"
+version = "0.5.11"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -640,4 +640,29 @@ end
         e = ArgumentError("Invalid value set for field `a`, expected Integer, got a value of type String (\"foo-bar\")")
         @test_throws e FieldErrorV3(; a="foo bar")
     end
+
+    @testset "Macro invocation doesn't require Legolas module name in caller's scope" begin
+        # https://github.com/beacon-biosignals/Legolas.jl/issues/91
+        module Namespace91
+            using Test
+            using Legolas: @schema, @version, tobuffer, read
+
+            # Define something else with the name Legolas
+            struct Legolas end
+
+            @schema "test.a91" A91
+
+            @version A91V1 begin
+                a::Int
+            end
+
+            # Try out a bunch of the auto-generated methods
+            # to ensure the wrong `Legolas` name isn't hidden in one of them
+            @test A91V1(; a=1) isa A91V1
+            @test hash(A91V1(; a=1)) isa UInt
+            @test A91V1(; a=1) == A91V1(; a=1)
+            @test isequal(A91V1(; a=1), A91V1(; a=1))
+            @test read(tobuffer([A91V1(; a=1)], A91V1SchemaVersion())).a == [1]
+        end # module
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,6 +181,31 @@ end
     @test isnothing(@schema "test.returns-nothing" ReturnsNothing)
 end
 
+# https://github.com/beacon-biosignals/Legolas.jl/issues/91
+module Namespace91
+    using Test
+    using Legolas: @schema, @version, tobuffer, read
+
+    # Define something else with the name Legolas
+    struct Legolas end
+
+    @schema "test.a91" A91
+
+    @version A91V1 begin
+        a::Int
+    end
+
+    @testset "Macro invocation doesn't require Legolas module name in caller's scope" begin
+        # Try out a bunch of the auto-generated methods
+        # to ensure the wrong `Legolas` name isn't hidden in one of them
+        @test A91V1(; a=1) isa A91V1
+        @test hash(A91V1(; a=1)) isa UInt
+        @test A91V1(; a=1) == A91V1(; a=1)
+        @test isequal(A91V1(; a=1), A91V1(; a=1))
+        @test read(tobuffer([A91V1(; a=1)], A91V1SchemaVersion())).a == [1]
+    end
+end # module
+
 @schema "test.parent" Parent
 @version ParentV1 begin
     x::Vector
@@ -639,30 +664,5 @@ end
     @testset "reports modifications" begin
         e = ArgumentError("Invalid value set for field `a`, expected Integer, got a value of type String (\"foo-bar\")")
         @test_throws e FieldErrorV3(; a="foo bar")
-    end
-
-    @testset "Macro invocation doesn't require Legolas module name in caller's scope" begin
-        # https://github.com/beacon-biosignals/Legolas.jl/issues/91
-        module Namespace91
-            using Test
-            using Legolas: @schema, @version, tobuffer, read
-
-            # Define something else with the name Legolas
-            struct Legolas end
-
-            @schema "test.a91" A91
-
-            @version A91V1 begin
-                a::Int
-            end
-
-            # Try out a bunch of the auto-generated methods
-            # to ensure the wrong `Legolas` name isn't hidden in one of them
-            @test A91V1(; a=1) isa A91V1
-            @test hash(A91V1(; a=1)) isa UInt
-            @test A91V1(; a=1) == A91V1(; a=1)
-            @test isequal(A91V1(; a=1), A91V1(; a=1))
-            @test read(tobuffer([A91V1(; a=1)], A91V1SchemaVersion())).a == [1]
-        end # module
     end
 end


### PR DESCRIPTION
Fixes https://github.com/beacon-biosignals/Legolas.jl/issues/91

Here, my understanding is that whenever we are emitting `quote`'d code, we need to interpolate in `Legolas` (or other names) if we wish to refer to the package and not whatever name `Legolas` exists in the macro-caller's scope.