### PR TITLE
Use common methods for Base functions instead of generating

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.5.14"
+version = "0.5.15"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -856,12 +856,19 @@ end
 ##### Base overload definitions
 #####
 
-function Base.:(==)(x::T, y::T) where {T<:AbstractRecord}
-    return all(i -> getfield(x, i) == getfield(y, i), 1:fieldcount(T))
+_typeof(r::AbstractRecord) = Base.unwrap_unionall(Base.typename(typeof(r)).wrapper)
+
+_type_equal(x::R, y::R) where {R<:AbstractRecord} = true
+_type_equal(x::AbstractRecord, y::AbstractRecord) = _typeof(x) === _typeof(y)
+
+function Base.:(==)(x::AbstractRecord, y::AbstractRecord)
+    _type_equal(x, y) || return false
+    return all(i -> getfield(x, i) == getfield(y, i), 1:nfields(x))
 end
 
-function Base.isequal(x::T, y::T) where {T<:AbstractRecord}
-    return all(i -> isequal(getfield(x, i), getfield(y, i)), 1:fieldcount(T))
+function Base.isequal(x::AbstractRecord, y::AbstractRecord)
+    _type_equal(x, y) || return false
+    return all(i -> isequal(getfield(x, i), getfield(y, i)), 1:nfields(x))
 end
 
 function Base.hash(r::AbstractRecord, h::UInt)

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -856,7 +856,7 @@ end
 ##### Base overload definitions
 #####
 
-_typeof(r::AbstractRecord) = Base.unwrap_unionall(Base.typename(typeof(r)).wrapper)
+_typeof(r::AbstractRecord) = record_type(schema_version_from_record(r))
 
 _type_equal(x::R, y::R) where {R<:AbstractRecord} = true
 _type_equal(x::AbstractRecord, y::AbstractRecord) = _typeof(x) === _typeof(y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -516,9 +516,7 @@ end
         c = ChildV1(; x=[1, 2], y="hello", z=missing)
         @test isequal(c, c)
         @test ismissing(c == c)
-        if UInt === UInt64  # value will be different depending on system word size
-            @test hash(c) === 0x07055951b3aa478e
-        end
+        @test hash(c) isa UInt  # NOTE: can't rely on particular values
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -526,10 +526,18 @@ end
         @test isequal(a, b)
         @test ismissing(a == b)
         @test hash(a) == hash(b)
-        @test UnionMissingV1(; a=missing, b=1) != UnionMissingV1(; a=missing, b=2)
-        @test !isequal(UnionMissingV1(; a=missing, b=1), UnionMissingV1(; a=missing, b=2))
-        @test ParamV1(; i=one(Int32)) == ParamV1(; i=one(Int64))
-        @test isequal(ParamV1(; i=one(Int32)), ParamV1(; i=one(Int64)))
+        u1 = UnionMissingV1(; a=missing, b=1)
+        u2 = UnionMissingV1(; a=missing, b=2)
+        @test u1 != u2
+        @test !isequal(u1, u2)
+        p32 = ParamV1(; i=one(Int32))
+        p64 = ParamV1(; i=one(Int64))
+        @test p32 == p64
+        @test isequal(p32, p64)
+        🧑 = ParentV1(; x=[4, 20], y="")
+        🧒 = ChildV1(; x=[4, 20], y="", z=missing)
+        @test 🧑 != 🧒
+        @test !isequal(🧑, 🧒)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -526,6 +526,8 @@ end
         @test hash(c) isa UInt  # NOTE: can't rely on particular values
         @test UnionMissingV1(; a=missing, b=1) != UnionMissingV1(; a=missing, b=2)
         @test !isequal(UnionMissingV1(; a=missing, b=1), UnionMissingV1(; a=missing, b=2))
+        @test ParamV1(; i=one(Int32)) == ParamV1(; i=one(Int64))
+        @test isequal(ParamV1(; i=one(Int32)), ParamV1(; i=one(Int64)))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -511,6 +511,15 @@ end
         @test_throws TypeError ParamV1(; i=1.0)
         @test_throws ArgumentError ParamV1{Int}(; i=1.1)
     end
+
+    @testset "equality and hashing" begin
+        c = ChildV1(; x=[1, 2], y="hello", z=missing)
+        @test isequal(c, c)
+        @test ismissing(c == c)
+        if UInt === UInt64  # value will be different depending on system word size
+            @test hash(c) === 0x07055951b3aa478e
+        end
+    end
 end
 
 @testset "miscellaneous Legolas/src/tables.jl tests" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -295,6 +295,13 @@ end
     xs::Union{Vector{String},Missing}
 end
 
+@schema "test.union-missing" UnionMissing
+
+@version UnionMissingV1 begin
+    a::Union{Int,Missing}
+    b::Union{Int,Missing}
+end
+
 @testset "`Legolas.@version` and associated utilities for declared `Legolas.SchemaVersion`s" begin
     @testset "Legolas.SchemaVersionDeclarationError" begin
         @test_throws SchemaVersionDeclarationError("malformed or missing field declaration(s)") eval(:(@version(NewV1, $(Expr(:block, LineNumberNode(1, :test))))))
@@ -517,6 +524,8 @@ end
         @test isequal(c, c)
         @test ismissing(c == c)
         @test hash(c) isa UInt  # NOTE: can't rely on particular values
+        @test UnionMissingV1(; a=missing, b=1) != UnionMissingV1(; a=missing, b=2)
+        @test !isequal(UnionMissingV1(; a=missing, b=1), UnionMissingV1(; a=missing, b=2))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -520,10 +520,12 @@ end
     end
 
     @testset "equality and hashing" begin
-        c = ChildV1(; x=[1, 2], y="hello", z=missing)
-        @test isequal(c, c)
-        @test ismissing(c == c)
-        @test hash(c) isa UInt  # NOTE: can't rely on particular values
+        a = ChildV1(; x=[1, 2], y="hello", z=missing)
+        b = ChildV1(; x=[1, 2], y="hello", z=missing)
+        @test a !== b
+        @test isequal(a, b)
+        @test ismissing(a == b)
+        @test hash(a) == hash(b)
         @test UnionMissingV1(; a=missing, b=1) != UnionMissingV1(; a=missing, b=2)
         @test !isequal(UnionMissingV1(; a=missing, b=1), UnionMissingV1(; a=missing, b=2))
         @test ParamV1(; i=one(Int32)) == ParamV1(; i=one(Int64))


### PR DESCRIPTION
Currently, methods for `==`, `isequal`, `hash`, and `NamedTuple` are generated by the `@version` macro for every row type that gets defined. The bodies of these methods always follow the same patterns, none of which require any information that's only available in the context where the definitions are generated. In fact, specific methods don't need to be generated at all; `AbstractRecord`s can all use the same generic methods for these functions. This provides the following additional benefits:
- When many schema versions are defined, this significantly reduces the excessive number of redundant methods which make method autocompletion effectively useless.
- Defining the generic methods in terms of regular functions rather than generating expressions in the macro means that it's easier to reason about the methods' behavior and ensure overall consistency. For example, moving from generating a chain of `==` and `&&` over a record's fields to directly using `all` means that `missing` is treated consistently (see #101).

Note that the generic method for `hash` as defined here loops over the fields in reverse order. This is to match the previous `foldr` behavior, ensuring that hashes don't change with this implementation.

Fixes #101.