### PR TITLE
Allow Children of Children Versions of the same Schema

### DIFF
--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -836,8 +836,6 @@ macro version(record_type, declared_fields_block=nothing)
 
             if $Legolas.declared(schema_version) && $Legolas.declaration(schema_version) != schema_version_declaration
                 throw(SchemaVersionDeclarationError("invalid redeclaration of existing schema version; all `@version` redeclarations must exactly match previous declarations"))
-            elseif parent isa $Legolas.SchemaVersion && $Legolas.name(parent) == schema_name
-                throw(SchemaVersionDeclarationError("cannot extend from another version of the same schema"))
             elseif parent isa $Legolas.SchemaVersion && !($Legolas._has_valid_child_field_types($declared_field_names_types, $Legolas.declared_fields(parent)))
                 throw(SchemaVersionDeclarationError("declared field types violate parent's field types"))
             else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -324,7 +324,6 @@ end
         @test_throws SchemaVersionDeclarationError("provided record type expression is malformed: BobV1 < DaveV1") @version(BobV1 < DaveV1, begin x end)
         @test_throws SchemaVersionDeclarationError("cannot have duplicate field names in `@version` declaration; received: $([:x, :y, :x, :z])") @version(ChildV2, begin x; y; x; z end)
         @test_throws SchemaVersionDeclarationError("cannot have field name which start with an underscore in `@version` declaration: $([:_X])") @version(ChildV2, begin x; X; _X end)
-        @test_throws SchemaVersionDeclarationError("cannot extend from another version of the same schema") @version(ChildV2 > ChildV1, begin x end)
         @test_throws SchemaVersionDeclarationError("declared field types violate parent's field types") @version(NewV1 > ParentV1, begin y::Int end)
         @test_throws SchemaVersionDeclarationError("declared field types violate parent's field types") @version(NewV1 > ChildV1, begin y::Int end)
         @test_throws SchemaVersionDeclarationError("invalid redeclaration of existing schema version; all `@version` redeclarations must exactly match previous declarations") @version(ParentV1, begin x; y end)


### PR DESCRIPTION
### Overview

Stemming from an internal discussion w/ @haberdashPI I was wanting to create a V2 schemaversion off of its V1 schemaversion. It wasn't clear _why_ this is disallowed? This PR loosens the constraint and allows for this situation.

```julia
using Legolas
using Legolas: @schema, @version

@schema "foo.bar" Bar

@version BarV1 begin
    a
end

@version BarV2 > BarV1 begin
    b
end
```