### PR TITLE
bump documenter version

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Legolas = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 
 [compat]
-Documenter = "0.24"
+Documenter = "1"


### PR DESCRIPTION
trivial change, but would error if we [lack docstrings](https://github.com/beacon-biosignals/Legolas.jl/pull/108#pullrequestreview-1793184479) in the future. E.g., deleting `is_valid_schema_name` from the docs locally to test:
```julia
julia> include("make.jl")
[ Info: SetupBuildDirectory: setting up build directory.
[ Info: Doctest: running doctests.
[ Info: ExpandTemplates: expanding markdown templates.
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
┌ Error: 1 docstring not included in the manual:
│ 
│     Legolas.is_valid_schema_name :: Tuple{AbstractString}
│ 
│ These are docstrings in the checked modules (configured with the modules keyword)
│ that are not included in canonical @docs or @autodocs blocks.
└ @ Documenter ~/.julia/packages/Documenter/1HwWe/src/utilities/utilities.jl:44
[ Info: Populate: populating indices.
ERROR: LoadError: `makedocs` encountered an error [:missing_docs] -- terminating build before rendering.
Stacktrace:
```