### PR TITLE
Add constraint support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.5.20"
+version = "0.5.21"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.5.19"
+version = "0.5.20"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,6 +14,7 @@ CurrentModule = Legolas
 Legolas.SchemaVersion
 Legolas.@schema
 Legolas.@version
+Legolas.@check
 Legolas.is_valid_schema_name
 Legolas.parse_identifier
 Legolas.name

--- a/examples/tour.jl
+++ b/examples/tour.jl
@@ -285,8 +285,8 @@ end
 # as this makes error message clearer:
 
 @test NamedTuple(FinitePositiveV1(; a=1)) == (a=1,)
-@test_throws "Legolas.CheckConstraintError: a > 0" FinitePositiveV1(; a=-1)
-@test_throws "Legolas.CheckConstraintError: isfinite(a)" FinitePositiveV1(; a=Inf)
+@test_throws "CheckConstraintError: a > 0" FinitePositiveV1(; a=-1)
+@test_throws "CheckConstraintError: isfinite(a)" FinitePositiveV1(; a=Inf)
 
 # All `@check` constraints must be defined after the fields and any processing on the field will occur before the
 # constraints are checked:

--- a/examples/tour.jl
+++ b/examples/tour.jl
@@ -285,8 +285,8 @@ end
 # as this makes error message clearer:
 
 @test NamedTuple(FinitePositiveV1(; a=1)) == (a=1,)
-@test_throws "CheckConstraintError: a > 0" FinitePositiveV1(; a=-1)
-@test_throws "CheckConstraintError: isfinite(a)" FinitePositiveV1(; a=Inf)
+@test_throws Legolas.CheckConstraintError(:(a > 0)) FinitePositiveV1(; a=-1)
+@test_throws Legolas.CheckConstraintError(:(isfinite(a))) FinitePositiveV1(; a=Inf)
 
 # All `@check` constraints must be defined after the fields and any processing on the field will occur before the
 # constraints are checked:

--- a/examples/tour.jl
+++ b/examples/tour.jl
@@ -268,6 +268,53 @@ end
 # property that child schema versions have a greater number of constraints than their parents.
 
 #####
+##### Constraints
+#####
+
+# Schema authors may want to restrict the allowed values for a field without having to define a new type. The `@check`
+# macro provides this functionality in a concise way and provides user friendly error messages
+
+@schema "example.finite-positive" FinitePositive
+@version FinitePositiveV1 begin
+    a::Real
+    @check a > 0
+    @check isfinite(a)
+end
+
+# We recommend defining multiple constraints instead of combining them into one (e.g. `@check a > 0 && isfinite(a)`)
+# as this makes error message clearer:
+
+@test NamedTuple(FinitePositiveV1(; a=1)) == (a=1,)
+@test_throws "Legolas.CheckConstraintError: a > 0" FinitePositiveV1(; a=-1)
+@test_throws "Legolas.CheckConstraintError: isfinite(a)" FinitePositiveV1(; a=Inf)
+
+# All `@check` constraints must be defined after the fields and any processing on the field will occur before the
+# constraints are checked:
+
+@schema "example.clamp" Clamp
+@version ClampV1 begin
+    a
+    b = clamp(b, 1, 5)
+    @check a == b
+end
+
+@test NamedTuple(ClampV1(; a=1, b=0)) == (a=1, b=1)
+
+# One use case supported by constraints is enforcing mutually exclusive use of multiple fields:
+
+@schema "example.mutually-exclusive" MutuallyExclusive
+@version MutuallyExclusiveV1 begin
+    x::Union{Real,Missing}
+    y::Union{String,Missing}
+    z::Union{Char,Missing}
+    @check !ismissing(x) ⊻ !ismissing(y) ⊻ !ismissing(z)  # `⊻` is the `xor` function
+end
+
+@test_throws Legolas.CheckConstraintError MutuallyExclusiveV1(; x=1, y="hi")
+@test_throws Legolas.CheckConstraintError MutuallyExclusiveV1(; x=1, z='a')
+@test isequal(NamedTuple(MutuallyExclusiveV1(; x=1)), (x=1, y=missing, z=missing))
+
+#####
 ##### Schema Versioning
 #####
 

--- a/ext/LegolasConstructionBaseExt.jl
+++ b/ext/LegolasConstructionBaseExt.jl
@@ -12,14 +12,21 @@ using Legolas: AbstractRecord
 if VERSION < v"1.7"
     ConstructionBase.getproperties(r::AbstractRecord) = NamedTuple(r)
 
-    # This is largely copy-paste from `ConstructionBase.setproperties_object`:
-    # https://github.com/JuliaObjects/ConstructionBase.jl/blob/cd24e541fd90ab54d2ee12ddd6ccd229be9a5f1e/src/ConstructionBase.jl#L211-L218
     function ConstructionBase.setproperties(r::R, patch::NamedTuple) where {R<:AbstractRecord}
-        nt = getproperties(r)
-        nt_new = merge(nt, patch)
-        ConstructionBase.check_patch_properties_exist(nt_new, nt, r, patch)
-        args = Tuple(nt_new)  # old Julia inference prefers if we wrap in `Tuple`
-        return constructorof(R)(args...)
+        if isdefined(ConstructionBase, :check_patch_properties_exist)
+            # This is largely copy-paste from `ConstructionBase.setproperties_object`:
+            # https://github.com/JuliaObjects/ConstructionBase.jl/blob/cd24e541fd90ab54d2ee12ddd6ccd229be9a5f1e/src/ConstructionBase.jl#L211-L218
+            nt = getproperties(r)
+            nt_new = merge(nt, patch)
+            ConstructionBase.check_patch_properties_exist(nt_new, nt, r, patch)
+            args = Tuple(nt_new)  # old Julia inference prefers if we wrap in `Tuple`
+            return constructorof(R)(args...)
+        else
+            # As of ConstructionBase 1.5.7 the internals of `ConstructionBase.setproperties_object` have changed:
+            # https://github.com/JuliaObjects/ConstructionBase.jl/blob/71fb5a5198f41f3ef29a53c01940cf7cf6b233eb/src/ConstructionBase.jl#L205-L209
+            ConstructionBase.check_patch_fields_exist(r, patch)
+            return ConstructionBase.setfields_object(r, patch)
+        end
     end
 end
 

--- a/src/Legolas.jl
+++ b/src/Legolas.jl
@@ -5,6 +5,7 @@ using Tables, Arrow, UUIDs
 const LEGOLAS_SCHEMA_QUALIFIED_METADATA_KEY = "legolas_schema_qualified"
 
 include("lift.jl")
+include("constraints.jl")
 include("schemas.jl")
 include("tables.jl")
 include("record_merge.jl")

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -9,5 +9,5 @@ end
 
 macro check(expr)
     quoted_expr = QuoteNode(expr)
-    return esc(:($expr || throw(Legolas.CheckConstraintError($quoted_expr))))
+    return :($(esc(expr)) || throw(CheckConstraintError($quoted_expr)))
 end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,0 +1,13 @@
+struct CheckConstraintError <: Exception
+    predicate::Expr
+end
+
+function Base.showerror(io::IO, ex::CheckConstraintError)
+    print(io, "$CheckConstraintError: $(ex.predicate)")
+    return nothing
+end
+
+macro check(expr)
+    quoted_expr = QuoteNode(expr)
+    return esc(:($expr || throw(Legolas.CheckConstraintError($quoted_expr))))
+end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -7,6 +7,17 @@ function Base.showerror(io::IO, ex::CheckConstraintError)
     return nothing
 end
 
+"""
+    @check expr
+
+Define a constraint for a schema version (e.g. `@check x > 0`) from a boolean expression.
+The `expr` should evaulate to `true` if the constraint is met or `false` if the constraint
+is violated. Multiple constraints may be defined for a schema version. All `@check`
+constraints defined with a [`@version`](@ref) must proceed all fields defined by the schema
+version.
+
+For more details and examples, please see `Legolas.jl/examples/tour.jl`.
+"""
 macro check(expr)
     quoted_expr = QuoteNode(expr)
     return :($(esc(expr)) || throw(CheckConstraintError($quoted_expr)))

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -787,12 +787,10 @@ macro version(record_type, declared_fields_block=nothing)
             if f isa LineNumberNode
                 continue
             elseif f isa Expr && f.head === :macrocall && f.args[1] === Symbol("@check")
-                # Avoids having to import `@check`
-                f.args[1] = Expr(:., :Legolas, QuoteNode(f.args[1]))
                 # Expand `@check` macro here so that we can reliably see the location of
                 # the user define `@check` when it fails. Ideally `Meta.replace_sourceloc!`
                 # would do this for us.
-                constraint_expr = Base.macroexpand(__module__, f)
+                constraint_expr = Base.macroexpand(Legolas, f)
                 if f.args[2] isa LineNumberNode
                     constraint_expr = Expr(:block, f.args[2], constraint_expr)
                 end

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -787,6 +787,8 @@ macro version(record_type, declared_fields_block=nothing)
             if f isa LineNumberNode
                 continue
             elseif f isa Expr && f.head === :macrocall && f.args[1] === Symbol("@check")
+                # Avoids having to import `@check`
+                f.args[1] = Expr(:., :Legolas, QuoteNode(f.args[1]))
                 # Expand `@check` macro here so that we can reliably see the location of
                 # the user define `@check` when it fails. Ideally `Meta.replace_sourceloc!`
                 # would do this for us.

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -786,9 +786,9 @@ macro version(record_type, declared_fields_block=nothing)
         for f in declared_fields_block.args
             if f isa LineNumberNode
                 continue
-            elseif f isa Expr && f.head === :macrocall && f.args[1] === Symbol("@assert")
-                # Expand `@assert` macro here so that we can reliably see the location of
-                # the user define `@assert` when it fails. Ideally `Meta.replace_sourceloc!`
+            elseif f isa Expr && f.head === :macrocall && f.args[1] === Symbol("@check")
+                # Expand `@check` macro here so that we can reliably see the location of
+                # the user define `@check` when it fails. Ideally `Meta.replace_sourceloc!`
                 # would do this for us.
                 constraint_expr = Base.macroexpand(__module__, f)
                 if f.args[2] isa LineNumberNode

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -787,10 +787,9 @@ macro version(record_type, declared_fields_block=nothing)
             if f isa LineNumberNode
                 continue
             elseif f isa Expr && f.head === :macrocall && f.args[1] === Symbol("@check")
-                # Expand `@check` macro here so that we can reliably see the location of
-                # the user define `@check` when it fails. Ideally `Meta.replace_sourceloc!`
-                # would do this for us.
                 constraint_expr = Base.macroexpand(Legolas, f)
+                # Update the expression such that a failure shows the location of the user
+                # defined `@check` call. Ideally `Meta.replace_sourceloc!` would do this.
                 if f.args[2] isa LineNumberNode
                     constraint_expr = Expr(:block, f.args[2], constraint_expr)
                 end

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -520,7 +520,7 @@ _schema_version_from_record_type(::Nothing) = nothing
 # includes the parent's declared field RHS statements. We cannot interpolate/incorporate these statements
 # in the child's record type definition because they may reference bindings from the parent's `@version`
 # callsite that are not available/valid at the child's `@version` callsite.
-function _generate_record_type_definitions(schema_version::SchemaVersion, record_type_symbol::Symbol)
+function _generate_record_type_definitions(schema_version::SchemaVersion, record_type_symbol::Symbol, constraints::AbstractVector)
     # generate `schema_version_type_alias_definition`
     T = Symbol(string(record_type_symbol, "SchemaVersion"))
     schema_version_type_alias_definition = :(const $T = $(Base.Meta.quot(typeof(schema_version))))
@@ -616,6 +616,7 @@ function _generate_record_type_definitions(schema_version::SchemaVersion, record
             function $R(; $(field_kwargs...))
                 $parent_record_application
                 $(field_assignments...)
+                $(constraints...)
                 return new($(keys(record_fields)...))
             end
         end
@@ -625,11 +626,13 @@ function _generate_record_type_definitions(schema_version::SchemaVersion, record
             function $R{$(type_param_names...)}(; $(field_kwargs...)) where {$(type_param_names...)}
                 $parent_record_application
                 $(parametric_field_assignments...)
+                $(constraints...)
                 return new{$(type_param_names...)}($(keys(record_fields)...))
             end
             function $R(; $(field_kwargs...))
                 $parent_record_application
                 $(field_assignments...)
+                $(constraints...)
                 return new{$((:(typeof($n)) for n in names_of_parameterized_fields)...)}($(keys(record_fields)...))
             end
         end
@@ -778,8 +781,26 @@ macro version(record_type, declared_fields_block=nothing)
 
     # parse `declared_fields_block`
     declared_field_statements = Any[]
+    declared_constraint_statements = Any[]
     if declared_fields_block isa Expr && declared_fields_block.head == :block && !isempty(declared_fields_block.args)
-        declared_field_statements = [f for f in declared_fields_block.args if !(f isa LineNumberNode)]
+        for f in declared_fields_block.args
+            if f isa LineNumberNode
+                continue
+            elseif f isa Expr && f.head === :macrocall && f.args[1] === Symbol("@assert")
+                # Expand `@assert` macro here so that we can reliably see the location of
+                # the user define `@assert` when it fails. Ideally `Meta.replace_sourceloc!`
+                # would do this for us.
+                constraint_expr = Base.macroexpand(__module__, f)
+                if f.args[2] isa LineNumberNode
+                    constraint_expr = Expr(:block, f.args[2], constraint_expr)
+                end
+                push!(declared_constraint_statements, constraint_expr)
+            elseif isempty(declared_constraint_statements)
+                push!(declared_field_statements, f)
+            else
+                return :(throw(SchemaVersionDeclarationError("all `@version` field expressions must be defined before constraints:\n", $(Base.Meta.quot(declared_fields_block)))))
+            end
+        end
     end
     declared_field_infos = DeclaredFieldInfo[]
     for stmt in declared_field_statements
@@ -800,6 +821,7 @@ macro version(record_type, declared_fields_block=nothing)
         return :(throw(SchemaVersionDeclarationError($msg)))
     end
     declared_field_names_types = Expr(:tuple, Expr(:parameters, (Expr(:kw, f.name, esc(f.type)) for f in declared_field_infos)...))
+    constraints = [Base.Meta.quot(ex) for ex in declared_constraint_statements]
 
     return quote
         if !isdefined((@__MODULE__), :__legolas_schema_name_from_prefix__)
@@ -827,7 +849,7 @@ macro version(record_type, declared_fields_block=nothing)
                 Base.@__doc__($(Base.Meta.quot(record_type)))
                 $(esc(:eval))($Legolas._generate_schema_version_definitions(schema_version, parent, $declared_field_names_types, schema_version_declaration))
                 $(esc(:eval))($Legolas._generate_validation_definitions(schema_version))
-                $(esc(:eval))($Legolas._generate_record_type_definitions(schema_version, $(Base.Meta.quot(record_type))))
+                $(esc(:eval))($Legolas._generate_record_type_definitions(schema_version, $(Base.Meta.quot(record_type)), [$(constraints...)]))
             end
         end
         nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Compat: current_exceptions
 using Legolas, Test, DataFrames, Arrow, UUIDs
-using Legolas: SchemaVersion, @schema, @version, SchemaVersionDeclarationError, DeclaredFieldInfo
+using Legolas: @schema, @version, @check, CheckConstraintError, SchemaVersion,
+               SchemaVersionDeclarationError, DeclaredFieldInfo
 using Accessors
 using Aqua
 
@@ -842,10 +843,10 @@ end
     @test r.a === 1
     @test r.b === 1.0
 
-    @test_throws AssertionError ConstraintV1(; a=1, b=2)
+    @test_throws CheckConstraintError ConstraintV1(; a=1, b=2)
 
     # For exceptions that occur during processing constraints its convenient to include the
-    # location of the `@assert` in the stacktrace.
+    # location of the `@check` in the stacktrace.
     try
         ConstraintV1(; a=1, b=missing)
         @test false
@@ -860,5 +861,5 @@ end
 end
 
 @testset "constraints must be after all fields" begin
-    @test_throws SchemaVersionDeclarationError @version(ConstraintV2, begin a; @assert a == 1; b end)
+    @test_throws SchemaVersionDeclarationError @version(ConstraintV2, begin a; @check a == 1; b end)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -847,7 +847,7 @@ end
     # In Julia 1.8+ we can test can test against "CheckConstraintError: a == b"
     try
         ConstraintV1(; a=1, b=2)
-        @test false
+        @test false  # Fail safe if the above line doesn't throw
     catch e
         @test e isa CheckConstraintError
         @test e.predicate == :(a == b)
@@ -855,7 +855,7 @@ end
 
     try
         ConstraintV1(; a=0, b=0)
-        @test false
+        @test false  # Fail safe if the above line doesn't throw
     catch e
         @test e isa CheckConstraintError
         @test e.predicate == :(a > 0)
@@ -863,7 +863,7 @@ end
 
     try
         ConstraintV1(; a=6, b=6)
-        @test false
+        @test false  # Fail safe if the above line doesn't throw
     catch e
         @test e isa CheckConstraintError
         @test e.predicate == :(a == b)
@@ -873,7 +873,7 @@ end
     # location of the `@check` in the stacktrace.
     try
         ConstraintV1(; a=1, b=missing)  # Fails when running check `a == b`
-        @test false
+        @test false  # Fail safe if the above line doesn't throw
     catch e
         @test e isa TypeError
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Compat: current_exceptions
 using Legolas, Test, DataFrames, Arrow, UUIDs
-using Legolas: @schema, @version, @check, SchemaVersion, SchemaVersionDeclarationError,
+using Legolas: @schema, @version, SchemaVersion, SchemaVersionDeclarationError,
                DeclaredFieldInfo
 using Accessors
 using Aqua

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -887,3 +887,7 @@ end
 @testset "constraints must be after all fields" begin
     @test_throws SchemaVersionDeclarationError @version(ConstraintV2, begin a; @check a == 1; b end)
 end
+
+@testset "CheckConstraintError" begin
+    @test sprint(showerror, CheckConstraintError(:(1 == 2))) == "CheckConstraintError: 1 == 2"
+end


### PR DESCRIPTION
Adds basic constraint support for Legolas schemas so you can define constraints on the relationships between fields. Previously, this could be worked around by adding such logic into a field:

```julia
julia> using Legolas: @schema, @version

julia> @schema "old.constraint" OldConstraint

julia> @version OldConstraintV1 begin
           a
           b = begin
               @assert a == b
               b
           end
       end

julia> OldConstraintV1(; a=1, b=2)
ERROR: ArgumentError: Invalid value set for field `b` (2)
Stacktrace:
 [1] OldConstraintV1(; a::Int64, b::Int64)
   @ Main ~/.julia/dev/Legolas/src/schemas.jl:545
 [2] top-level scope
   @ REPL[4]:1

caused by: AssertionError: a == b
Stacktrace:
 [1] macro expansion
   @ ./REPL[3]:4 [inlined]
 [2] OldConstraintV1(; a::Int64, b::Int64)
   @ Main ~/.julia/dev/Legolas/src/schemas.jl:580
 [3] top-level scope
   @ REPL[4]:1
```

Unfortunately, the old approach would produce an extra `ArgumentError` which could create confusion. Additionally, when utilizing more complicated constructor logic for `b` these kinds of constraints can be less clear than declaring them separately like so:

```julia
julia> using Legolas: @schema, @version

julia> @schema "new.constraint" NewConstraint

julia> @version NewConstraintV1 begin
           a
           b
           @check a == b
       end

julia> NewConstraintV1(; a=1, b=2)
ERROR: Legolas.CheckConstraintError: a == b
Stacktrace:
 [1] macro expansion
   @ ./REPL[3]:4 [inlined]
 [2] NewConstraintV1(; a::Int64, b::Int64)
   @ Main ~/.julia/dev/Legolas/src/schemas.jl:619
 [3] top-level scope
   @ REPL[4]:1
```

Closes #69