### PR TITLE
Add check for all missing arguments to schema.

### DIFF
--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -634,7 +634,7 @@ function _generate_record_type_definitions(schema_version::SchemaVersion, record
     R = record_type_symbol
     kwargs_from_row = [Expr(:kw, n, :(get(row, $(Base.Meta.quot(n)), $Legolas.DefaultArgument()))) for n in keys(record_fields)]
     outer_constructor_definitions = quote
-        $R(::NamedTuple{}) = $R($Legolas.DontCheckArgs())
+        $R(::NamedTuple{(), Tuple{}}) = $R($Legolas.DontCheckArgs())
         $R(row) = $R(; $(kwargs_from_row...))
     end
     result = gensym("result")

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -644,7 +644,7 @@ function _generate_record_type_definitions(schema_version::SchemaVersion, record
             # tried to implement the warning for empty arguments by defining `$R()` we would
             # be defining the same method twice.
             function $R(flag::$Legolas.CheckArgsFlag=$Legolas.CheckArgs(); $(field_kwargs...))
-                $(result) = $Legolas._check_empty_args(flag, $string(R), $(keys(record_fields)...))
+                $(result) = $Legolas._check_empty_args(flag, $(string(R)), $(keys(record_fields)...))
                 $((:($key = $(result)[$i]) for (i, key) in enumerate(keys(record_fields)))...)
                 $parent_record_application
                 $(field_assignments...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -772,7 +772,7 @@ end
     end
 
     @testset "appropriate warnings with zero-argument constructor" begin
-        msg = r"arguments.*FieldErrorV1.*are all missing.*FieldErrorV1SchemaVersion"
+        msg = r"no arguments passed.*FieldErrorV1.*are you sure.*FieldErrorV1SchemaVersion"i
         @test_logs (:warn, msg) FieldErrorV1()
         @test_logs FieldErrorV1(; a=missing)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -771,15 +771,10 @@ end
         @test_throws e FieldErrorV3(; a="foo bar")
     end
 
-    @testset "appropriate all-missing warnings" begin
+    @testset "appropriate warnings with zero-argument constructor" begin
         msg = r"arguments.*FieldErrorV1.*are all missing.*FieldErrorV1SchemaVersion"
         @test_logs (:warn, msg) FieldErrorV1()
-        @test_logs FieldErrorV1(Legolas.AllMissing())
-    end
-
-    @testset "errors when expecting all missing values" begin
-        ex = ArgumentError("Expected all arguments passed to `FieldErrorV1` to be missing.")
-        @test_throws ex FieldErrorV1(Legolas.AllMissing(); a="a")
+        @test_logs FieldErrorV1(; a=missing)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -770,6 +770,16 @@ end
         e = ArgumentError("Invalid value set for field `a`, expected Integer, got a value of type String (\"foo-bar\")")
         @test_throws e FieldErrorV3(; a="foo bar")
     end
+
+    @testset "appropriate all-missing warnings" begin
+        msg = r"arguments.*FieldErrorV1.*are all missing.*FieldErrorV1SchemaVersion"
+        @test_logs (:warn, msg) FieldErrorV1()
+        @test_logs FieldErrorV1(Legolas.AllMissing())
+    end
+
+    @testset "errors when expecting all missing values" begin
+        @test_throws r"expected.*all.*missing"i FieldErrorV1(Legolas.AllMissing(); a="a")
+    end
 end
 
 #####

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -773,8 +773,20 @@ end
 
     @testset "appropriate warnings with zero-argument constructor" begin
         msg = r"no arguments passed.*FieldErrorV1.*are you sure.*FieldErrorV1SchemaVersion"i
+
         @test_logs (:warn, msg) FieldErrorV1()
         @test_logs FieldErrorV1(; a=missing)
+        @test_logs FieldErrorV1((;))
+
+        @test_logs (:warn, msg) begin
+            @test_throws ArgumentError FieldErrorV1{String,Int}()
+        end
+        @test_logs begin
+            @test_throws ArgumentError FieldErrorV1{String,Int}(; a=missing)
+        end
+        @test_logs begin
+            @test_throws ArgumentError FieldErrorV1{String,Int}((;))
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -778,7 +778,8 @@ end
     end
 
     @testset "errors when expecting all missing values" begin
-        @test_throws r"expected.*all.*missing"i FieldErrorV1(Legolas.AllMissing(); a="a")
+        ex = ArgumentError("Expected all arguments passed to `FieldErrorV1` to be missing.")
+        @test_throws ex FieldErrorV1(Legolas.AllMissing(); a="a")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -691,6 +691,10 @@ end
     a::Integer = replace(a, ' ' => '-')
 end
 
+@version FieldErrorV4 begin
+    x::Union{String,Missing}
+end
+
 @testset "Legolas record constructor error handling" begin
     @testset "field constructor error" begin
         ex_stack = try
@@ -772,11 +776,15 @@ end
     end
 
     @testset "appropriate warnings with zero-argument constructor" begin
-        msg = r"no arguments passed.*FieldErrorV1.*are you sure.*FieldErrorV1SchemaVersion"i
+        msg = r"no arguments passed.*FieldErrorV.*are you sure.*FieldErrorV(1|4)SchemaVersion"i
 
         @test_logs (:warn, msg) FieldErrorV1()
         @test_logs FieldErrorV1(; a=missing)
         @test_logs FieldErrorV1((;))
+
+        @test_logs (:warn, msg) FieldErrorV4()
+        @test_logs FieldErrorV4(; x=missing)
+        @test_logs FieldErrorV4((;))
 
         @test_logs (:warn, msg) begin
             @test_throws ArgumentError FieldErrorV1{String,Int}()


### PR DESCRIPTION
A common mistake in using Legolas is to call `MySchemaV1()` instead of `MySchemaV1SchemaVersion()`. Since calling `MySchemaV1()` is rarely intentional, this PR flags a warning when that method is called. The warning can be silenced by calling `MySchemaV1(Legolas.AllMissing())` to signal that, yes, you really do want a record with all missing fields.
