### PR TITLE
fix @check docstring

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -13,7 +13,7 @@ end
 Define a constraint for a schema version (e.g. `@check x > 0`) from a boolean expression.
 The `expr` should evaulate to `true` if the constraint is met or `false` if the constraint
 is violated. Multiple constraints may be defined for a schema version. All `@check`
-constraints defined with a [`@version`](@ref) must proceed all fields defined by the schema
+constraints defined with a [`@version`](@ref) must follow all fields defined by the schema
 version.
 
 For more details and examples, please see `Legolas.jl/examples/tour.jl`.


### PR DESCRIPTION
Based on actual use cases and examples in the tour, "follow" was meant, not "proceed"