### PR TITLE
Adjust to upcoming Julia 1.12 change in implicit world age increment

### DIFF
--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -865,6 +865,8 @@ macro version(record_type, declared_fields_block=nothing)
     declared_field_names_types = Expr(:tuple, Expr(:parameters, (Expr(:kw, f.name, esc(f.type)) for f in declared_field_infos)...))
     constraints = [Base.Meta.quot(ex) for ex in declared_constraint_statements]
 
+    latestworld = isdefined(Core, :var"@latestworld") ? :(@Core.latestworld) : nothing
+
     return quote
         if !isdefined((@__MODULE__), :__legolas_schema_name_from_prefix__)
             throw(SchemaVersionDeclarationError("no prior `@schema` declaration found in current module"))
@@ -890,7 +892,9 @@ macro version(record_type, declared_fields_block=nothing)
             else
                 Base.@__doc__($(Base.Meta.quot(record_type)))
                 $(esc(:eval))($Legolas._generate_schema_version_definitions(schema_version, parent, $declared_field_names_types, schema_version_declaration))
+                $latestworld
                 $(esc(:eval))($Legolas._generate_validation_definitions(schema_version))
+                $latestworld
                 $(esc(:eval))($Legolas._generate_record_type_definitions(schema_version, $(Base.Meta.quot(record_type)), [$(constraints...)]))
             end
         end


### PR DESCRIPTION
In 1.12, we'll be cleaning up and making consistent when world age increment happens. This package is currently relying on implicit world age increments that may go away in 1.12. See https://github.com/JuliaLang/julia/pull/56509. This PR adds appropriate annotations that the world age increment is required because the `_generate_*` invocations in the macro read the result of the previous eval. This PR strictly retains existing behavior. A potentially better solution may be to `invokelatest` the `_generate_*` functions, which would also allow this code to work at non-toplevel (which may nor may not be desirable).