### PR TITLE
Add accepted_field_type for VersionNumber

### DIFF
--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -305,7 +305,7 @@ accepted_field_type(sv::SchemaVersion, ::Type{<:Vector{T}}) where T = AbstractVe
 accepted_field_type(::SchemaVersion, ::Type{Vector}) = AbstractVector
 accepted_field_type(sv::SchemaVersion, ::Type{Union{T,Missing}}) where {T} = Union{accepted_field_type(sv, T),Missing}
 accepted_field_type(::SchemaVersion, ::Type{Missing}) = Missing
-accpeted_field_type(::SchemaVersion, ::Type{VersionNumber}) = Union{VersionNumber,AbstractString}
+accepted_field_type(::SchemaVersion, ::Type{VersionNumber}) = Union{VersionNumber,AbstractString}
 
 """
     Legolas.find_violation(ts::Tables.Schema, sv::Legolas.SchemaVersion)

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -305,7 +305,7 @@ accepted_field_type(sv::SchemaVersion, ::Type{<:Vector{T}}) where T = AbstractVe
 accepted_field_type(::SchemaVersion, ::Type{Vector}) = AbstractVector
 accepted_field_type(sv::SchemaVersion, ::Type{Union{T,Missing}}) where {T} = Union{accepted_field_type(sv, T),Missing}
 accepted_field_type(::SchemaVersion, ::Type{Missing}) = Missing
-accpeted_field_type(::SchemaVersion, ::Type{VersionNumber}) = Union{VersionNumber,String}
+accpeted_field_type(::SchemaVersion, ::Type{VersionNumber}) = Union{VersionNumber,AbstractString}
 
 """
     Legolas.find_violation(ts::Tables.Schema, sv::Legolas.SchemaVersion)

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -305,6 +305,7 @@ accepted_field_type(sv::SchemaVersion, ::Type{<:Vector{T}}) where T = AbstractVe
 accepted_field_type(::SchemaVersion, ::Type{Vector}) = AbstractVector
 accepted_field_type(sv::SchemaVersion, ::Type{Union{T,Missing}}) where {T} = Union{accepted_field_type(sv, T),Missing}
 accepted_field_type(::SchemaVersion, ::Type{Missing}) = Missing
+accpeted_field_type(::SchemaVersion, ::Type{VersionNumber}) = Union{VersionNumber,String}
 
 """
     Legolas.find_violation(ts::Tables.Schema, sv::Legolas.SchemaVersion)


### PR DESCRIPTION
VersionNumber is a base type. Defined as a struct, it has a pretty gnarly typing. If we want other languages that can easily construct arrow tables that are compatible with Legolas then we want to allow strings to be accepted as VersionNumbers. This PR implements this change. 