### PR TITLE
Declare public API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.5.23"
+version = "0.5.24"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/Legolas.jl
+++ b/src/Legolas.jl
@@ -2,6 +2,18 @@ module Legolas
 
 using Tables, Arrow, UUIDs
 
+# public API
+if VERSION >= v"1.11.0-DEV.469"
+    eval(Meta.parse("""
+    public SchemaVersion, @schema, @version, @check, is_valid_schema_name,
+           parse_identifier, name, version, identifier, schema_provider, parent,
+           declared_fields, declaration, record_type, schema_version_from_record,
+           declared, find_violation, find_violations, complies_with, validate,
+           accepted_field_type, extract_schema_version, write, read, tobuffer,
+           lift, construct, record_merge, gather, locations, materialize
+    """))
+end
+
 const LEGOLAS_SCHEMA_QUALIFIED_METADATA_KEY = "legolas_schema_qualified"
 const LEGOLAS_SCHEMA_PROVIDER_NAME_METADATA_KEY = "legolas_julia_schema_provider_name"
 const LEGOLAS_SCHEMA_PROVIDER_VERSION_METADATA_KEY = "legolas_julia_schema_provider_version"


### PR DESCRIPTION
This stops these warnings:

```julia
help?> Legolas.write
  │ Warning
  │
  │  The following bindings may be internal; they may change or be removed in future
  │  versions:
  │
  │    •  Legolas.write

  Legolas.write(io_or_path, table, sv::SchemaVersion; validate::Bool=true, kwargs...)

  Write table to io_or_path, inserting the appropriate legolas_schema_qualified field in the
  written out Arrow metadata.

  If validate is true, Legolas.validate(Tables.schema(table), vs) will be invoked before the table
  is written out to io_or_path.

  Any other provided kwargs are forwarded to an internal invocation of Arrow.write.

  Note that io_or_path may be any type that supports Base.write(io_or_path, bytes::Vector{UInt8}).
```

and also allows programmatically checking dependencies use the public API only and things like that.

Uses https://discourse.julialang.org/t/is-compat-jl-worth-it-for-the-public-keyword/119041/2 since `public` is a keyword on 1.11+.