### PR TITLE
fix for tests on Julia 1.13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,9 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+        exclude:
+            - os: macos-latest
+              version: min
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,26 +9,23 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1'
-          - '1.6'
+          - 'min'
+          - 'pre'
         os:
           - ubuntu-latest
-        arch:
-          - x64
+          - macos-latest
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ dmypy.json
 docs/build/
 docs/site/
 Manifest.toml
+Manifest-v*.toml
 
 # misc
 *.DS_Store

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.5.24"
+version = "0.5.25"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legolas"
 uuid = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.5.25"
+version = "0.5.24"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -919,7 +919,7 @@ end
     catch e
         @test e isa TypeError
 
-        bt = Base.process_backtrace(catch_backtrace())
+        bt = Base.process_backtrace(stacktrace(catch_backtrace()))
         sf = bt[1][1]::Base.StackFrame
         @test string(sf.file) == @__FILE__
         @test sf.line == CONSTRAINT_V1_EQUAL_CONSTRAINT_LINE


### PR DESCRIPTION
The tests relied on non-public API, which changed on 1.13. This updates the test to avoid that and updates CI a bit to improve coverage around Julia versions. Versioned Manifests are also now ignored.